### PR TITLE
fix: map Float type to number in JSON Schema OneOf compositions

### DIFF
--- a/lib/easy_talk/builders/composition_builder.rb
+++ b/lib/easy_talk/builders/composition_builder.rb
@@ -50,7 +50,18 @@ module EasyTalk
       # @return [Array<Hash>] The array of schemas.
       def schemas
         items.map do |type|
-          type.respond_to?(:schema) ? type.schema : { type: type.to_s.downcase }
+          if type.respond_to?(:schema)
+            type.schema
+          else
+            # Map Float type to 'number' in JSON Schema
+            json_type = case type.to_s
+                       when 'Float', 'BigDecimal'
+                         'number'
+                       else
+                         type.to_s.downcase
+                       end
+            { type: json_type }
+          end
         end
       end
 

--- a/spec/easy_talk/one_of_spec.rb
+++ b/spec/easy_talk/one_of_spec.rb
@@ -168,4 +168,45 @@ RSpec.describe EasyTalk::Types::Composer::OneOf do
       expect(user.json_schema).to include_json(expected_schema)
     end
   end
+
+  context 'with primitive types in OneOf' do
+    let(:model_class) do
+      Class.new do
+        include EasyTalk::Model
+
+        def self.name
+          'PrimitiveTypesModel'
+        end
+
+        define_schema do
+          property :string_or_number, T::OneOf[String, Float], optional: true
+          property :string_or_integer, T::OneOf[String, Integer], optional: true
+        end
+      end
+    end
+
+    it 'correctly maps Float to "number" JSON Schema type' do
+      json_schema = model_class.json_schema
+      # The properties hash is accessed with string keys in the final schema
+      string_or_number = json_schema["properties"]["string_or_number"]
+      expect(string_or_number).to include_json(
+        oneOf: [
+          { type: 'string' },
+          { type: 'number' }  # Float should map to 'number', not 'float'
+        ]
+      )
+    end
+
+    it 'correctly maps Integer to "integer" JSON Schema type' do
+      json_schema = model_class.json_schema
+      # The properties hash is accessed with string keys in the final schema
+      string_or_integer = json_schema["properties"]["string_or_integer"]
+      expect(string_or_integer).to include_json(
+        oneOf: [
+          { type: 'string' },
+          { type: 'integer' }
+        ]
+      )
+    end
+  end
 end


### PR DESCRIPTION
When using T::OneOf[String, Float] in schema definitions, the Float type was being incorrectly mapped to "float" in the generated JSON Schema. This is invalid according to JSON Schema spec, which requires "number" instead of "float" for floating point values.

This change modifies the CompositionBuilder class to properly map Ruby Float and BigDecimal types to the JSON Schema "number" type, ensuring the generated schema is valid for external API calls like Anthropic.

Added test case to verify both Float->number and Integer->integer mapping in OneOf compositions.