### PR TITLE
feat: Support Rails 8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'activerecord', '>= 7.0'
+gem 'activerecord', '>= 7.0', '< 9.0'
 gem 'pry-byebug', '>= 3.10'
 gem 'rake', '>= 13.1'
 gem 'rspec', '>= 3.0'

--- a/easy_talk.gemspec
+++ b/easy_talk.gemspec
@@ -30,8 +30,9 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activemodel', '~> 7.0'
-  spec.add_dependency 'activesupport', '~> 7.0'
+  spec.add_dependency 'activemodel', ['>= 7.0', '< 9.0']
+  spec.add_dependency 'activesupport', ['>= 7.0', '< 9.0']
+  spec.add_dependency 'js_regex', '~> 3.0'
   spec.add_dependency 'sorbet-runtime', '~> 0.5'
 
   spec.metadata['rubygems_mfa_required'] = 'true'

--- a/lib/easy_talk/builders/integer_builder.rb
+++ b/lib/easy_talk/builders/integer_builder.rb
@@ -7,6 +7,7 @@ module EasyTalk
     # Builder class for integer properties.
     class IntegerBuilder < BaseBuilder
       extend T::Sig
+
       VALID_OPTIONS = {
         minimum: { type: Integer, key: :minimum },
         maximum: { type: Integer, key: :maximum },

--- a/lib/easy_talk/builders/string_builder.rb
+++ b/lib/easy_talk/builders/string_builder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'base_builder'
+require 'js_regex' # Compile the ruby regex to JS regex
 require 'sorbet-runtime' # Add the import statement for the T module
 
 module EasyTalk
@@ -8,6 +9,7 @@ module EasyTalk
     # Builder class for string properties.
     class StringBuilder < BaseBuilder
       extend T::Sig
+
       VALID_OPTIONS = {
         format: { type: String, key: :format },
         pattern: { type: String, key: :pattern },
@@ -21,6 +23,13 @@ module EasyTalk
       sig { params(name: Symbol, constraints: Hash).void }
       def initialize(name, constraints = {})
         super(name, { type: 'string' }, constraints, VALID_OPTIONS)
+      end
+
+      def build
+        super.tap do |schema|
+          pattern = schema[:pattern]
+          schema[:pattern] = JsRegex.new(pattern).source if pattern.is_a?(String)
+        end
       end
     end
   end

--- a/spec/easy_talk/array_wrapping_spec.rb
+++ b/spec/easy_talk/array_wrapping_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Array wrapping' do
                                                     'type' => 'string'
                                                   }, 'zip' => {
                                                     'type' => 'string',
-                                                    'pattern' => '\A[0-9]{5}(?:-[0-9]{4})?\z'
+                                                    'pattern' => '^[0-9]{5}(?:-[0-9]{4})?$'
                                                   }
                                                 },
                                                 'additionalProperties' => false,

--- a/spec/easy_talk/builders/string_builder_spec.rb
+++ b/spec/easy_talk/builders/string_builder_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe EasyTalk::Builders::StringBuilder do
       end
 
       it 'includes pattern constraint' do
-        builder = described_class.new(:zip, pattern: '^\d{5}(-\d{4})?$')
+        builder = described_class.new(:zip, pattern: '\\A\d{5}(-\d{4})?\\z')
         expect(builder.build).to eq({ type: 'string', pattern: '^\d{5}(-\d{4})?$' })
       end
 
@@ -61,14 +61,14 @@ RSpec.describe EasyTalk::Builders::StringBuilder do
         builder = described_class.new(:password,
                                       min_length: 8,
                                       max_length: 32,
-                                      pattern: '^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$',
+                                      pattern: '\A(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}\z',
                                       description: 'Must contain letters and numbers')
 
         expect(builder.build).to eq({
                                       type: 'string',
                                       minLength: 8,
                                       maxLength: 32,
-                                      pattern: '^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$',
+                                      pattern: '^(?=(?:[\uD800-\uDBFF][\uDC00-\uDFFF]|[^\n\uD800-\uDFFF])*[A-Za-z])(?=(?:[\uD800-\uDBFF][\uDC00-\uDFFF]|[^\n\uD800-\uDFFF])*\d)[A-Za-z\d]{8,}$',
                                       description: 'Must contain letters and numbers'
                                     })
       end

--- a/spec/easy_talk/builders/typed_array_builder_spec.rb
+++ b/spec/easy_talk/builders/typed_array_builder_spec.rb
@@ -45,11 +45,11 @@ RSpec.describe EasyTalk::Builders::TypedArrayBuilder do
         expect(prop).to eq({ type: 'array', const: %w[one], items: { type: 'string' } })
       end
 
-      pending 'with an invalid constraint value' do
-        pending 'raises an error' do # unclear why this does not throw an error
+      context 'with an invalid constraint value' do
+        it 'raises an error' do
           expect do
             described_class.new(:name, T::Array[String], enum: [1, 2, 3]).build
-          end.to raise_error(TypeError)
+          end.to raise_error(EasyTalk::ConstraintError)
         end
       end
     end

--- a/spec/easy_talk/examples/company_employees_spec.rb
+++ b/spec/easy_talk/examples/company_employees_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'json for user model' do
                         },
                         zip: {
                           type: 'string',
-                          pattern: '\A[0-9]{5}(?:-[0-9]{4})?\z'
+                          pattern: '^[0-9]{5}(?:-[0-9]{4})?$'
                         }
                       },
                       required: %w[

--- a/spec/easy_talk/examples/contact_data_spec.rb
+++ b/spec/easy_talk/examples/contact_data_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Contact info. Example using compositional keyword: oneOf' do
               properties: {
                 phone_number: {
                   type: 'string',
-                  pattern: '\A(?:\+?1[-. ]?)?\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})\z'
+                  pattern: '^(?:\+?1[\-. ]?)?\(?([0-9]{3})\)?[\-. ]?([0-9]{3})[\-. ]?([0-9]{4})$'
                 }
               },
               required: [

--- a/spec/easy_talk/examples/library_book_collection_spec.rb
+++ b/spec/easy_talk/examples/library_book_collection_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Library Book Collection. Example using compositional keyword: not' do
+RSpec.describe 'Library Book Collection' do
   let(:book) do
     Class.new do
       include EasyTalk::Model
@@ -15,7 +15,7 @@ RSpec.describe 'Library Book Collection. Example using compositional keyword: no
         title 'Book'
         property :title, String, description: 'The title of the book.'
         property :author, String, description: "The name of the book's author."
-        property :ISBN, String, pattern: '^(\\d{3}-?\\d{10})$', description: 'The International Standard Book Number.'
+        property :ISBN, String, pattern: '\A(\d{3}-?\d{10})\z', description: 'The International Standard Book Number.'
         property :publicationYear, Integer, description: 'The year the book was published.'
       end
     end
@@ -30,12 +30,12 @@ RSpec.describe 'Library Book Collection. Example using compositional keyword: no
       end
 
       define_schema do
-        property :ISSN, String, pattern: '^\\d{4}-\\d{4}$', description: 'The International Standard Serial Number for periodicals.'
+        property :ISSN, String, pattern: '\A\d{4}-\d{4}\z', description: 'The International Standard Serial Number for periodicals.'
       end
     end
   end
 
-  let(:expected_json_schema) do
+  let(:expected_book_schema) do
     {
       type: 'object',
       title: 'Book',
@@ -51,7 +51,7 @@ RSpec.describe 'Library Book Collection. Example using compositional keyword: no
         ISBN: {
           type: 'string',
           description: 'The International Standard Book Number.',
-          pattern: '^(\\d{3}-?\\d{10})$'
+          pattern: '^(\d{3}-?\d{10})$'
         },
         publicationYear: {
           type: 'integer',
@@ -63,29 +63,31 @@ RSpec.describe 'Library Book Collection. Example using compositional keyword: no
         author
         ISBN
         publicationYear
-      ],
-      '$defs': {
-        Magazine: {
-          type: 'object',
-          properties: {
-            ISSN: {
-              type: 'string',
-              description: 'The International Standard Serial Number for periodicals.',
-              pattern: '^\\d{4}-\\d{4}$'
-            }
-          },
-          required: [
-            'ISSN'
-          ]
-        }
-      },
-      not: {
-        '$ref': '#/$defs/Magazine'
-      }
+      ]
     }
   end
 
-  pending 'returns a json schema for the book class' do
-    expect(Book.json_schema).to include_json(expected_json_schema)
+  let(:expected_magazine_schema) do
+    {
+      type: 'object',
+      properties: {
+        ISSN: {
+          type: 'string',
+          description: 'The International Standard Serial Number for periodicals.',
+          pattern: '^\d{4}-\d{4}$'
+        }
+      },
+      required: [
+        'ISSN'
+      ]
+    }
+  end
+
+  it 'returns a json schema for the book class' do
+    expect(book.json_schema).to include_json(expected_book_schema)
+  end
+
+  it 'returns a json schema for the magazine class' do
+    expect(magazine.json_schema).to include_json(expected_magazine_schema)
   end
 end

--- a/spec/easy_talk/examples/payment_spec.rb
+++ b/spec/easy_talk/examples/payment_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe 'Payment object example' do
                 },
                 CardCVV: {
                   type: 'string',
-                  pattern: '\A(?:\d{3}|\d{4})\z'
+                  pattern: '^(?:\d{3}|\d{4})$'
                 }
               },
               additionalProperties: false,

--- a/spec/easy_talk/examples/vehicle_registration_spec.rb
+++ b/spec/easy_talk/examples/vehicle_registration_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe 'Vehicle Registration System example' do
             },
             contact_number: {
               type: 'string',
-              pattern: '\A[0-9]{10}\z'
+              pattern: '^[0-9]{10}$'
             }
           },
           required: %w[
@@ -144,7 +144,7 @@ RSpec.describe 'Vehicle Registration System example' do
           properties: {
             registration_number: {
               type: 'string',
-              pattern: '\A[A-Z0-9]{7}\z'
+              pattern: '^[A-Z0-9]{7}$'
             },
             registration_date: {
               type: 'string',

--- a/spec/easy_talk/model_spec.rb
+++ b/spec/easy_talk/model_spec.rb
@@ -339,6 +339,7 @@ RSpec.describe EasyTalk::Model do
     it 'has build_schema as a public class method' do
       test_class = Class.new do
         include EasyTalk::Model
+
         def self.name = 'TestClass'
       end
 

--- a/spec/easy_talk/tools/function_builder_spec.rb
+++ b/spec/easy_talk/tools/function_builder_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe EasyTalk::Tools::FunctionBuilder do
   let(:model) do
     Class.new do
       include EasyTalk::Model
+
       def self.name
         'MyModel'
       end


### PR DESCRIPTION
Addresses https://github.com/sergiobayona/easy_talk/issues/57.

### Changes
* Support Rails 7.x and 8.x
* Compile Ruby regexes to JS compatible regexes (_see below_)
* Update library book collection spec to remove the `not` option 

---

While testing, I noticed that the library book spec was failing due to multiline validations on `^` and `$` anchors:

```
The provided regular expression is using multiline anchors (^ or $), which may present a security risk. Did you mean to use \A and \z, or forgot to add the :multiline => true option?
```

Upon further investigation, it appears that there are some differences between Ruby and JavaScript regular expressions and [JSON Schema does not support `/A` & `/z` anchors](https://json-schema.org/understanding-json-schema/reference/regular_expressions).

To fix this, I decided to compile the Ruby `Regexp` to JS format via `JsRegex`.