### PR TITLE
Allow nilable nested models.

### DIFF
--- a/lib/easy_talk/model.rb
+++ b/lib/easy_talk/model.rb
@@ -69,6 +69,11 @@ module EasyTalk
           # Get the defined type and the currently assigned value
           defined_type = prop_definition[:type]
           current_value = public_send(prop_name)
+          nilable_type = defined_type.respond_to?(:nilable?) && defined_type.nilable?
+
+          next if nilable_type && current_value.nil?
+
+          defined_type = T::Utils::Nilable.get_underlying_type(defined_type) if nilable_type
 
           # Check if the type is another EasyTalk::Model and the value is a Hash
           next unless defined_type.is_a?(Class) && defined_type.include?(EasyTalk::Model) && current_value.is_a?(Hash)

--- a/lib/easy_talk/property.rb
+++ b/lib/easy_talk/property.rb
@@ -189,7 +189,7 @@ module EasyTalk
     #   {"type"=>["string", "null"]}
     def build_nilable_schema
       # Extract the non-nil type from the Union
-      actual_type = type.types.find { |t| t.raw_type != NilClass }
+      actual_type = T::Utils::Nilable.get_underlying_type(type)
 
       return { type: 'null' } unless actual_type
 

--- a/lib/easy_talk/validation_builder.rb
+++ b/lib/easy_talk/validation_builder.rb
@@ -65,8 +65,8 @@ module EasyTalk
     end
 
     # Check if the type is nilable (e.g., T.nilable(String))
-    def nilable_type?
-      @type.respond_to?(:nilable?) && @type.nilable?
+    def nilable_type?(type = @type)
+      type.respond_to?(:nilable?) && type.nilable?
     end
 
     # Extract the inner type from a complex type like T.nilable(String)
@@ -118,6 +118,8 @@ module EasyTalk
         end
       elsif type.to_s.include?('T::Boolean')
         [TrueClass, FalseClass] # Return both boolean classes
+      elsif nilable_type?(type)
+        extract_inner_type(type)
       else
         String # Default fallback
       end

--- a/spec/easy_talk/examples/nilable_nested_model_spec.rb
+++ b/spec/easy_talk/examples/nilable_nested_model_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'combining nested models with nilable' do
+  let(:address) do
+    Class.new do
+      include EasyTalk::Model
+
+      def self.name
+        'Address'
+      end
+    end
+  end
+  let(:expected_json_schema) do
+    {
+      "title" => "Company",
+      "type" => "object",
+      "properties" => {
+        "name" => { "type" => "string" },
+        "address" => {
+          "title" => "Address",
+          "type" => %w[object null],
+          "properties" => {
+            "street" => { "type" => "string" },
+            "city" => { "type" => "string" },
+            "state" => { "type" => "string" }
+          },
+          "additionalProperties" => false,
+          "required" => %w[street city state]
+        }
+      },
+      "additionalProperties" => false,
+      "required" => %w[name address]
+    }
+  end
+
+  let(:company) do
+    Class.new do
+      include EasyTalk::Model
+
+      def self.name
+        'Company'
+      end
+    end
+  end
+
+  before do
+    stub_const('Address', address)
+    stub_const('Company', company)
+
+    Address.define_schema do
+      title 'Address'
+      property :street, String
+      property :city, String
+      property :state, String
+    end
+
+    Company.define_schema do
+      title 'Company'
+      property :name, String
+      property :address, T.nilable(Address)
+    end
+  end
+
+  it 'builds a JSON schema' do
+    expect(Company.json_schema).to eq(expected_json_schema)
+  end
+
+  it "allows passing nil as a value for the nested model" do
+    company = Company.new(name: 'Acme', address: nil)
+
+    expect(company.address).to be_nil
+    expect(company).to be_valid
+  end
+
+  it "allows passing a hash as a value for the nested model" do
+    company = Company.new(name: 'Acme', address: { street: '123 Main St', city: 'Anytown', state: 'NY' })
+
+    expect(company).to be_valid
+    expect(company.address).to be_a(Address)
+    expect(company.address).to be_valid
+    expect(company.address.street).to eq('123 Main St')
+    expect(company.address.city).to eq('Anytown')
+    expect(company.address.state).to eq('NY')
+  end
+end


### PR DESCRIPTION
The previous versions of the library would fail on code like this:

```ruby
class Address
  include EasyTalk::Model

  define_schema do
    property :street, String
  end
end

class Company
  include EasyTalk::Model

  define_schema do
    property :address, T.nilable(Address)
  end
end

There were a number of issues:
- the JSON schema wouldn't build
- the validations would assume a String type for the nested model
- the nested model would be assigned as Hash, instead of being converted
  to an instance of the model class
```