### PR TITLE
[FIX][65] Allow ``nil`` for optional properties with pattern validation

### DIFF
--- a/lib/easy_talk/validation_builder.rb
+++ b/lib/easy_talk/validation_builder.rb
@@ -136,7 +136,7 @@ module EasyTalk
       apply_format_validation(@constraints[:format]) if @constraints[:format]
 
       # Handle pattern (regex) constraints
-      @klass.validates @property_name, format: { with: Regexp.new(@constraints[:pattern]) } if @constraints[:pattern]
+      @klass.validates @property_name, format: { with: Regexp.new(@constraints[:pattern]) }, allow_nil: optional? if @constraints[:pattern]
 
       # Handle length constraints
       begin

--- a/spec/easy_talk/validations_spec.rb
+++ b/spec/easy_talk/validations_spec.rb
@@ -171,8 +171,8 @@ RSpec.describe 'Auto Validations' do
         end
 
         define_schema do
-          property :required_name, String
-          property :optional_name, String, optional: true
+          property :required_name, String, pattern: /\A\w+\z/
+          property :optional_name, String, pattern: /\A\w+\z/, optional: true
           property :nilable_name, T.nilable(String)
         end
       end


### PR DESCRIPTION
This fixes https://github.com/sergiobayona/easy_talk/issues/65