### PR TITLE
feat: standardize validation error output (#88)

### DIFF
--- a/lib/easy_talk.rb
+++ b/lib/easy_talk.rb
@@ -20,6 +20,7 @@ module EasyTalk
   require 'easy_talk/property'
   require 'easy_talk/schema_definition'
   require 'easy_talk/validation_builder'
+  require 'easy_talk/error_formatter'
   require 'easy_talk/tools/function_builder'
   require 'easy_talk/version'
 

--- a/lib/easy_talk/configuration.rb
+++ b/lib/easy_talk/configuration.rb
@@ -14,7 +14,7 @@ module EasyTalk
     }.freeze
 
     attr_accessor :default_additional_properties, :nilable_is_optional, :auto_validations, :schema_version, :schema_id,
-                  :use_refs, :validation_adapter
+                  :use_refs, :validation_adapter, :default_error_format, :error_type_base_uri, :include_error_codes
     attr_reader :property_naming_strategy
 
     def initialize
@@ -25,6 +25,9 @@ module EasyTalk
       @schema_version = :none
       @schema_id = nil
       @use_refs = false
+      @default_error_format = :flat
+      @error_type_base_uri = 'about:blank'
+      @include_error_codes = true
       self.property_naming_strategy = :identity
     end
 

--- a/lib/easy_talk/error_formatter.rb
+++ b/lib/easy_talk/error_formatter.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require_relative 'error_formatter/error_code_mapper'
+require_relative 'error_formatter/path_converter'
+require_relative 'error_formatter/base'
+require_relative 'error_formatter/flat'
+require_relative 'error_formatter/json_pointer'
+require_relative 'error_formatter/rfc7807'
+require_relative 'error_formatter/jsonapi'
+
+module EasyTalk
+  # Module for formatting ActiveModel validation errors into standardized formats.
+  #
+  # Provides multiple output formats for API responses:
+  # - `:flat` - Simple flat array of field/message/code objects
+  # - `:json_pointer` - Array with JSON Pointer (RFC 6901) paths
+  # - `:rfc7807` - RFC 7807 Problem Details format
+  # - `:jsonapi` - JSON:API specification error format
+  #
+  # @example Using via model instance methods
+  #   user = User.new(name: '')
+  #   user.valid?
+  #
+  #   user.validation_errors                    # Uses default format from config
+  #   user.validation_errors_flat               # Flat format
+  #   user.validation_errors_json_pointer       # JSON Pointer format
+  #   user.validation_errors_rfc7807            # RFC 7807 format
+  #   user.validation_errors_jsonapi            # JSON:API format
+  #
+  # @example Using the format method directly
+  #   EasyTalk::ErrorFormatter.format(user.errors, format: :rfc7807, title: 'Custom Title')
+  #
+  module ErrorFormatter
+    # Map of format symbols to formatter classes
+    FORMATTERS = {
+      flat: Flat,
+      json_pointer: JsonPointer,
+      rfc7807: Rfc7807,
+      jsonapi: Jsonapi
+    }.freeze
+
+    class << self
+      # Format validation errors using the specified format.
+      #
+      # @param errors [ActiveModel::Errors] The errors object to format
+      # @param format [Symbol] The output format (:flat, :json_pointer, :rfc7807, :jsonapi)
+      # @param options [Hash] Format-specific options
+      # @return [Hash, Array] The formatted errors
+      # @raise [ArgumentError] If the format is not recognized
+      #
+      # @example
+      #   EasyTalk::ErrorFormatter.format(user.errors, format: :flat)
+      #   EasyTalk::ErrorFormatter.format(user.errors, format: :rfc7807, title: 'Validation Error')
+      def format(errors, format: nil, **options)
+        format ||= EasyTalk.configuration.default_error_format
+        formatter_class = FORMATTERS[format.to_sym]
+
+        raise ArgumentError, "Unknown error format: #{format}. Valid formats: #{FORMATTERS.keys.join(', ')}" unless formatter_class
+
+        formatter_class.new(errors, options).format
+      end
+    end
+
+    # Instance methods mixed into EasyTalk::Model classes.
+    #
+    # Provides convenient methods for formatting validation errors
+    # on model instances.
+    module InstanceMethods
+      # Format validation errors using the default or specified format.
+      #
+      # @param format [Symbol] The output format (optional, uses config default)
+      # @param options [Hash] Format-specific options
+      # @return [Hash, Array] The formatted errors
+      #
+      # @example
+      #   user.validation_errors
+      #   user.validation_errors(format: :rfc7807, title: 'User Error')
+      def validation_errors(format: nil, **)
+        ErrorFormatter.format(errors, format: format, **)
+      end
+
+      # Format validation errors as a flat array.
+      #
+      # @param options [Hash] Format options
+      # @option options [Boolean] :include_codes Whether to include error codes
+      # @return [Array<Hash>] Array of error objects
+      #
+      # @example
+      #   user.validation_errors_flat
+      #   # => [{ "field" => "name", "message" => "can't be blank", "code" => "blank" }]
+      def validation_errors_flat(**)
+        ErrorFormatter.format(errors, format: :flat, **)
+      end
+
+      # Format validation errors with JSON Pointer paths.
+      #
+      # @param options [Hash] Format options
+      # @option options [Boolean] :include_codes Whether to include error codes
+      # @return [Array<Hash>] Array of error objects with pointer paths
+      #
+      # @example
+      #   user.validation_errors_json_pointer
+      #   # => [{ "pointer" => "/properties/name", "message" => "can't be blank", "code" => "blank" }]
+      def validation_errors_json_pointer(**)
+        ErrorFormatter.format(errors, format: :json_pointer, **)
+      end
+
+      # Format validation errors as RFC 7807 Problem Details.
+      #
+      # @param options [Hash] Format options
+      # @option options [String] :title The problem title
+      # @option options [Integer] :status The HTTP status code
+      # @option options [String] :detail The problem detail message
+      # @option options [String] :type_base_uri Base URI for error type
+      # @option options [String] :type The error type suffix
+      # @option options [Boolean] :include_codes Whether to include error codes
+      # @return [Hash] The Problem Details object
+      #
+      # @example
+      #   user.validation_errors_rfc7807
+      #   user.validation_errors_rfc7807(title: 'User Validation Failed', status: 400)
+      def validation_errors_rfc7807(**)
+        ErrorFormatter.format(errors, format: :rfc7807, **)
+      end
+
+      # Format validation errors according to JSON:API specification.
+      #
+      # @param options [Hash] Format options
+      # @option options [String] :status The HTTP status code (as string)
+      # @option options [String] :title The error title
+      # @option options [String] :source_prefix The source pointer prefix
+      # @option options [Boolean] :include_codes Whether to include error codes
+      # @return [Hash] The JSON:API error object
+      #
+      # @example
+      #   user.validation_errors_jsonapi
+      #   user.validation_errors_jsonapi(title: 'Validation Error', source_prefix: '/data')
+      def validation_errors_jsonapi(**)
+        ErrorFormatter.format(errors, format: :jsonapi, **)
+      end
+    end
+  end
+end

--- a/lib/easy_talk/error_formatter/base.rb
+++ b/lib/easy_talk/error_formatter/base.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module EasyTalk
+  module ErrorFormatter
+    # Abstract base class for error formatters.
+    #
+    # Provides common functionality for transforming ActiveModel::Errors
+    # into standardized formats. Subclasses implement the `format` method
+    # to produce specific output formats.
+    #
+    # @abstract Subclass and implement {#format} to create a formatter.
+    #
+    # @example Creating a custom formatter
+    #   class CustomFormatter < EasyTalk::ErrorFormatter::Base
+    #     def format
+    #       error_entries.map do |entry|
+    #         { custom_field: entry[:attribute], custom_message: entry[:message] }
+    #       end
+    #     end
+    #   end
+    #
+    class Base
+      attr_reader :errors, :options
+
+      # Initialize a new formatter.
+      #
+      # @param errors [ActiveModel::Errors] The errors object to format
+      # @param options [Hash] Formatting options
+      # @option options [Boolean] :include_codes Whether to include error codes
+      def initialize(errors, options = {})
+        @errors = errors
+        @options = options
+      end
+
+      # Format the errors into the target format.
+      #
+      # @abstract
+      # @return [Hash, Array] The formatted errors
+      # @raise [NotImplementedError] if the subclass does not implement this method
+      def format
+        raise NotImplementedError, "#{self.class} must implement #format"
+      end
+
+      protected
+
+      # Check if error codes should be included in the output.
+      #
+      # @return [Boolean]
+      def include_codes?
+        @options.fetch(:include_codes, EasyTalk.configuration.include_error_codes)
+      end
+
+      # Build a normalized list of error entries from ActiveModel::Errors.
+      #
+      # Each entry contains:
+      # - :attribute - The attribute name (may include dots for nested)
+      # - :message - The error message
+      # - :full_message - The full error message with attribute name
+      # - :type - The error type from errors.details (e.g., :blank, :too_short)
+      # - :detail_options - Additional options from the error detail
+      #
+      # @return [Array<Hash>] The normalized error entries
+      def error_entries
+        @error_entries ||= build_error_entries
+      end
+
+      private
+
+      def build_error_entries
+        # Group details by attribute for matching
+        details_by_attr = {}
+        errors.details.each do |attr, detail_list|
+          details_by_attr[attr] = detail_list.dup
+        end
+
+        errors.map do |error|
+          attr = error.attribute
+          detail = find_and_consume_detail(details_by_attr, attr)
+
+          {
+            attribute: attr,
+            message: error.message,
+            full_message: error.full_message,
+            type: detail[:error],
+            detail_options: detail.except(:error)
+          }
+        end
+      end
+
+      # Find and consume a detail entry for an attribute.
+      # This handles the case where an attribute has multiple errors.
+      def find_and_consume_detail(details_by_attr, attribute)
+        detail_list = details_by_attr[attribute]
+        return {} if detail_list.nil? || detail_list.empty?
+
+        detail_list.shift || {}
+      end
+    end
+  end
+end

--- a/lib/easy_talk/error_formatter/error_code_mapper.rb
+++ b/lib/easy_talk/error_formatter/error_code_mapper.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module EasyTalk
+  module ErrorFormatter
+    # Maps ActiveModel validation error types to semantic error codes.
+    #
+    # ActiveModel's `errors.details` provides the validation type (e.g., :blank, :too_short).
+    # This class maps those types to standardized semantic codes for API responses.
+    #
+    # @example
+    #   ErrorCodeMapper.map(:blank)        # => "blank"
+    #   ErrorCodeMapper.map(:too_short)    # => "too_short"
+    #   ErrorCodeMapper.map(:invalid)      # => "invalid_format"
+    #
+    class ErrorCodeMapper
+      # Mapping of ActiveModel error types to semantic codes
+      VALIDATION_TO_CODE = {
+        # Presence validations
+        blank: 'blank',
+        present: 'present',
+        empty: 'empty',
+
+        # Format validations
+        invalid: 'invalid_format',
+
+        # Length validations
+        too_short: 'too_short',
+        too_long: 'too_long',
+        wrong_length: 'wrong_length',
+
+        # Numericality validations
+        not_a_number: 'not_a_number',
+        not_an_integer: 'not_an_integer',
+        greater_than: 'too_small',
+        greater_than_or_equal_to: 'too_small',
+        less_than: 'too_large',
+        less_than_or_equal_to: 'too_large',
+        equal_to: 'not_equal',
+        other_than: 'equal',
+        odd: 'not_odd',
+        even: 'not_even',
+
+        # Inclusion/exclusion validations
+        inclusion: 'not_included',
+        exclusion: 'excluded',
+
+        # Other validations
+        taken: 'taken',
+        confirmation: 'confirmation',
+        accepted: 'not_accepted'
+      }.freeze
+
+      class << self
+        # Map an ActiveModel error type to a semantic code.
+        #
+        # @param error_type [Symbol, String] The ActiveModel error type
+        # @return [String] The semantic error code
+        def map(error_type)
+          VALIDATION_TO_CODE[error_type.to_sym] || error_type.to_s
+        end
+
+        # Extract the error code from an ActiveModel error detail hash.
+        #
+        # @param detail [Hash] The error detail from errors.details
+        # @return [String] The semantic error code
+        #
+        # @example
+        #   ErrorCodeMapper.code_from_detail({ error: :blank })
+        #   # => "blank"
+        #
+        #   ErrorCodeMapper.code_from_detail({ error: :too_short, count: 2 })
+        #   # => "too_short"
+        def code_from_detail(detail)
+          error_key = detail[:error]
+          return 'unknown' unless error_key
+
+          map(error_key)
+        end
+      end
+    end
+  end
+end

--- a/lib/easy_talk/error_formatter/flat.rb
+++ b/lib/easy_talk/error_formatter/flat.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module EasyTalk
+  module ErrorFormatter
+    # Formats validation errors as a simple flat array.
+    #
+    # This is the simplest format, providing an array of error objects
+    # with field name, message, and optional error code.
+    #
+    # @example Output
+    #   [
+    #     { "field" => "name", "message" => "can't be blank", "code" => "blank" },
+    #     { "field" => "email.address", "message" => "is invalid", "code" => "invalid_format" }
+    #   ]
+    #
+    class Flat < Base
+      # Format the errors as a flat array.
+      #
+      # @return [Array<Hash>] Array of error objects
+      def format
+        error_entries.map do |entry|
+          build_error_object(entry)
+        end
+      end
+
+      private
+
+      def build_error_object(entry)
+        error = {
+          'field' => PathConverter.to_flat(entry[:attribute]),
+          'message' => entry[:message]
+        }
+        error['code'] = ErrorCodeMapper.map(entry[:type]) if include_codes? && entry[:type]
+        error
+      end
+    end
+  end
+end

--- a/lib/easy_talk/error_formatter/json_pointer.rb
+++ b/lib/easy_talk/error_formatter/json_pointer.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module EasyTalk
+  module ErrorFormatter
+    # Formats validation errors using JSON Pointer (RFC 6901) paths.
+    #
+    # Converts attribute paths to JSON Pointer format pointing to the
+    # property location in the JSON Schema.
+    #
+    # @example Output
+    #   [
+    #     { "pointer" => "/properties/name", "message" => "can't be blank", "code" => "blank" },
+    #     { "pointer" => "/properties/email/properties/address", "message" => "is invalid", "code" => "invalid_format" }
+    #   ]
+    #
+    class JsonPointer < Base
+      # Format the errors as an array with JSON Pointer paths.
+      #
+      # @return [Array<Hash>] Array of error objects with pointer paths
+      def format
+        error_entries.map do |entry|
+          build_error_object(entry)
+        end
+      end
+
+      private
+
+      def build_error_object(entry)
+        error = {
+          'pointer' => PathConverter.to_json_pointer(entry[:attribute]),
+          'message' => entry[:message]
+        }
+        error['code'] = ErrorCodeMapper.map(entry[:type]) if include_codes? && entry[:type]
+        error
+      end
+    end
+  end
+end

--- a/lib/easy_talk/error_formatter/jsonapi.rb
+++ b/lib/easy_talk/error_formatter/jsonapi.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module EasyTalk
+  module ErrorFormatter
+    # Formats validation errors according to the JSON:API specification.
+    #
+    # JSON:API defines a standard error format with specific fields for
+    # status, source, title, detail, and optional code.
+    #
+    # @see https://jsonapi.org/format/#error-objects
+    #
+    # @example Output
+    #   {
+    #     "errors" => [
+    #       {
+    #         "status" => "422",
+    #         "code" => "blank",
+    #         "source" => { "pointer" => "/data/attributes/name" },
+    #         "title" => "Invalid Attribute",
+    #         "detail" => "Name can't be blank"
+    #       }
+    #     ]
+    #   }
+    #
+    class Jsonapi < Base
+      # Default values for JSON:API error fields
+      DEFAULT_STATUS = '422'
+      DEFAULT_TITLE = 'Invalid Attribute'
+
+      # Format the errors as a JSON:API error response.
+      #
+      # @return [Hash] The JSON:API error object with "errors" array
+      def format
+        {
+          'errors' => build_errors_array
+        }
+      end
+
+      private
+
+      def build_errors_array
+        error_entries.map do |entry|
+          build_error_object(entry)
+        end
+      end
+
+      def build_error_object(entry)
+        error = {
+          'status' => options.fetch(:status, DEFAULT_STATUS).to_s,
+          'source' => {
+            'pointer' => PathConverter.to_jsonapi_pointer(
+              entry[:attribute],
+              prefix: options.fetch(:source_prefix, '/data/attributes')
+            )
+          },
+          'title' => options.fetch(:title, DEFAULT_TITLE),
+          'detail' => entry[:full_message]
+        }
+        error['code'] = ErrorCodeMapper.map(entry[:type]) if include_codes? && entry[:type]
+        error
+      end
+    end
+  end
+end

--- a/lib/easy_talk/error_formatter/path_converter.rb
+++ b/lib/easy_talk/error_formatter/path_converter.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module EasyTalk
+  module ErrorFormatter
+    # Converts attribute paths between different formats.
+    #
+    # EasyTalk uses dot notation for nested model errors (e.g., "email.address").
+    # This class converts those paths to different standard formats:
+    # - JSON Pointer (RFC 6901): /properties/email/properties/address
+    # - JSON:API: /data/attributes/email/address
+    # - Flat: email.address (unchanged)
+    #
+    # @example
+    #   PathConverter.to_json_pointer("email.address")
+    #   # => "/properties/email/properties/address"
+    #
+    #   PathConverter.to_jsonapi_pointer("email.address")
+    #   # => "/data/attributes/email/address"
+    #
+    class PathConverter
+      class << self
+        # Convert an attribute path to JSON Schema pointer format.
+        #
+        # @param attribute [Symbol, String] The attribute path (e.g., "email.address")
+        # @return [String] The JSON Pointer path (e.g., "/properties/email/properties/address")
+        def to_json_pointer(attribute)
+          parts = attribute.to_s.split('.')
+          return "/properties/#{parts.first}" if parts.length == 1
+
+          parts.map { |part| "/properties/#{part}" }.join
+        end
+
+        # Convert an attribute path to JSON:API pointer format.
+        #
+        # @param attribute [Symbol, String] The attribute path
+        # @param prefix [String] The path prefix (default: "/data/attributes")
+        # @return [String] The JSON:API pointer path
+        def to_jsonapi_pointer(attribute, prefix: '/data/attributes')
+          parts = attribute.to_s.split('.')
+          "#{prefix}/#{parts.join('/')}"
+        end
+
+        # Return the attribute path as-is (flat format).
+        #
+        # @param attribute [Symbol, String] The attribute path
+        # @return [String] The attribute as a string
+        def to_flat(attribute)
+          attribute.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/easy_talk/error_formatter/rfc7807.rb
+++ b/lib/easy_talk/error_formatter/rfc7807.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module EasyTalk
+  module ErrorFormatter
+    # Formats validation errors according to RFC 7807 (Problem Details for HTTP APIs).
+    #
+    # RFC 7807 defines a standard format for describing errors in HTTP APIs.
+    # This formatter produces a Problem Details object with validation errors
+    # in an extended "errors" array.
+    #
+    # @see https://tools.ietf.org/html/rfc7807
+    #
+    # @example Output
+    #   {
+    #     "type" => "https://example.com/validation-error",
+    #     "title" => "Validation Failed",
+    #     "status" => 422,
+    #     "detail" => "The request contains invalid parameters",
+    #     "errors" => [
+    #       { "pointer" => "/properties/name", "detail" => "can't be blank", "code" => "blank" }
+    #     ]
+    #   }
+    #
+    class Rfc7807 < Base
+      # Default values for RFC 7807 fields
+      DEFAULT_TITLE = 'Validation Failed'
+      DEFAULT_STATUS = 422
+      DEFAULT_DETAIL = 'The request contains invalid parameters'
+
+      # Format the errors as an RFC 7807 Problem Details object.
+      #
+      # @return [Hash] The Problem Details object
+      def format
+        {
+          'type' => error_type_uri,
+          'title' => options.fetch(:title, DEFAULT_TITLE),
+          'status' => options.fetch(:status, DEFAULT_STATUS),
+          'detail' => options.fetch(:detail, DEFAULT_DETAIL),
+          'errors' => build_errors_array
+        }
+      end
+
+      private
+
+      def error_type_uri
+        base_uri = options.fetch(:type_base_uri, EasyTalk.configuration.error_type_base_uri)
+        type_suffix = options.fetch(:type, 'validation-error')
+        return type_suffix if base_uri.nil? || base_uri == 'about:blank'
+
+        "#{base_uri.chomp('/')}/#{type_suffix}"
+      end
+
+      def build_errors_array
+        error_entries.map do |entry|
+          build_error_object(entry)
+        end
+      end
+
+      def build_error_object(entry)
+        error = {
+          'pointer' => PathConverter.to_json_pointer(entry[:attribute]),
+          'detail' => entry[:message]
+        }
+        error['code'] = ErrorCodeMapper.map(entry[:type]) if include_codes? && entry[:type]
+        error
+      end
+    end
+  end
+end

--- a/lib/easy_talk/model.rb
+++ b/lib/easy_talk/model.rb
@@ -10,6 +10,7 @@ require 'active_model'
 require_relative 'builders/object_builder'
 require_relative 'schema_definition'
 require_relative 'validation_builder'
+require_relative 'error_formatter'
 
 module EasyTalk
   # The `Model` module is a mixin that provides functionality for defining and accessing the schema of a model.
@@ -41,6 +42,7 @@ module EasyTalk
       base.include ActiveModel::Validations
       base.extend ActiveModel::Callbacks
       base.include(InstanceMethods)
+      base.include(ErrorFormatter::InstanceMethods)
     end
 
     # Instance methods mixed into models that include EasyTalk::Model

--- a/spec/easy_talk/error_formatter/base_spec.rb
+++ b/spec/easy_talk/error_formatter/base_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe EasyTalk::ErrorFormatter::Base do
+  let(:test_class) do
+    Class.new do
+      include EasyTalk::Model
+
+      def self.name = 'BaseFormatterTest'
+
+      define_schema do
+        property :name, String
+      end
+    end
+  end
+
+  describe '#format' do
+    it 'raises NotImplementedError' do
+      instance = test_class.new(name: nil)
+      instance.valid?
+
+      formatter = described_class.new(instance.errors)
+
+      expect { formatter.format }.to raise_error(
+        NotImplementedError,
+        'EasyTalk::ErrorFormatter::Base must implement #format'
+      )
+    end
+  end
+
+  describe '#error_entries' do
+    it 'builds normalized error entries' do
+      instance = test_class.new(name: nil)
+      instance.valid?
+
+      formatter = described_class.new(instance.errors)
+      entries = formatter.send(:error_entries)
+
+      expect(entries).to be_an(Array)
+      expect(entries.first).to include(
+        attribute: :name,
+        message: a_kind_of(String),
+        full_message: a_kind_of(String),
+        type: a_kind_of(Symbol)
+      )
+    end
+  end
+
+  describe '#include_codes?' do
+    context 'when include_codes option is set' do
+      it 'returns the option value' do
+        instance = test_class.new
+        formatter = described_class.new(instance.errors, include_codes: false)
+        expect(formatter.send(:include_codes?)).to be false
+
+        formatter = described_class.new(instance.errors, include_codes: true)
+        expect(formatter.send(:include_codes?)).to be true
+      end
+    end
+
+    context 'when include_codes option is not set' do
+      it 'returns the config value' do
+        original = EasyTalk.configuration.include_error_codes
+
+        EasyTalk.configuration.include_error_codes = false
+        instance = test_class.new
+        formatter = described_class.new(instance.errors)
+        expect(formatter.send(:include_codes?)).to be false
+
+        EasyTalk.configuration.include_error_codes = original
+      end
+    end
+  end
+end

--- a/spec/easy_talk/error_formatter/error_code_mapper_spec.rb
+++ b/spec/easy_talk/error_formatter/error_code_mapper_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe EasyTalk::ErrorFormatter::ErrorCodeMapper do
+  describe '.map' do
+    it 'maps :blank to "blank"' do
+      expect(described_class.map(:blank)).to eq('blank')
+    end
+
+    it 'maps :invalid to "invalid_format"' do
+      expect(described_class.map(:invalid)).to eq('invalid_format')
+    end
+
+    it 'maps :too_short to "too_short"' do
+      expect(described_class.map(:too_short)).to eq('too_short')
+    end
+
+    it 'maps :too_long to "too_long"' do
+      expect(described_class.map(:too_long)).to eq('too_long')
+    end
+
+    it 'maps :greater_than to "too_small"' do
+      expect(described_class.map(:greater_than)).to eq('too_small')
+    end
+
+    it 'maps :less_than to "too_large"' do
+      expect(described_class.map(:less_than)).to eq('too_large')
+    end
+
+    it 'maps :inclusion to "not_included"' do
+      expect(described_class.map(:inclusion)).to eq('not_included')
+    end
+
+    it 'returns the error type as string for unknown types' do
+      expect(described_class.map(:custom_error)).to eq('custom_error')
+    end
+
+    it 'accepts string input' do
+      expect(described_class.map('blank')).to eq('blank')
+    end
+  end
+
+  describe '.code_from_detail' do
+    it 'extracts code from detail hash' do
+      detail = { error: :blank }
+      expect(described_class.code_from_detail(detail)).to eq('blank')
+    end
+
+    it 'extracts code from detail with additional options' do
+      detail = { error: :too_short, count: 2 }
+      expect(described_class.code_from_detail(detail)).to eq('too_short')
+    end
+
+    it 'returns "unknown" for nil error key' do
+      detail = {}
+      expect(described_class.code_from_detail(detail)).to eq('unknown')
+    end
+  end
+end

--- a/spec/easy_talk/error_formatter/flat_spec.rb
+++ b/spec/easy_talk/error_formatter/flat_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe EasyTalk::ErrorFormatter::Flat do
+  let(:test_class) do
+    Class.new do
+      include EasyTalk::Model
+
+      def self.name = 'FlatFormatterTest'
+
+      define_schema do
+        property :name, String, min_length: 2
+        property :email, String, format: 'email'
+        property :age, Integer, minimum: 0
+      end
+    end
+  end
+
+  describe '#format' do
+    context 'with simple errors' do
+      it 'formats errors as flat array with codes' do
+        instance = test_class.new(name: '', email: 'invalid', age: -1)
+        instance.valid?
+
+        formatter = described_class.new(instance.errors)
+        result = formatter.format
+
+        expect(result).to be_an(Array)
+        expect(result.length).to be >= 3 # May include presence errors
+
+        name_error = result.find { |e| e['field'] == 'name' }
+        expect(name_error).to include(
+          'field' => 'name',
+          'message' => a_kind_of(String)
+        )
+        expect(name_error['code']).to be_a(String)
+      end
+    end
+
+    context 'without error codes' do
+      before do
+        EasyTalk.configuration.include_error_codes = false
+      end
+
+      after do
+        EasyTalk.configuration.include_error_codes = true
+      end
+
+      it 'omits code when include_codes is false' do
+        instance = test_class.new(name: '')
+        instance.valid?
+
+        formatter = described_class.new(instance.errors)
+        result = formatter.format
+
+        expect(result.first).not_to have_key('code')
+      end
+    end
+
+    context 'with include_codes option override' do
+      it 'respects per-call include_codes option' do
+        instance = test_class.new(name: '')
+        instance.valid?
+
+        formatter = described_class.new(instance.errors, include_codes: false)
+        result = formatter.format
+
+        expect(result.first).not_to have_key('code')
+      end
+    end
+  end
+end

--- a/spec/easy_talk/error_formatter/json_pointer_spec.rb
+++ b/spec/easy_talk/error_formatter/json_pointer_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe EasyTalk::ErrorFormatter::JsonPointer do
+  let(:test_class) do
+    Class.new do
+      include EasyTalk::Model
+
+      def self.name = 'JsonPointerFormatterTest'
+
+      define_schema do
+        property :name, String, min_length: 2
+        property :age, Integer, minimum: 0
+      end
+    end
+  end
+
+  describe '#format' do
+    it 'formats errors with JSON Pointer paths' do
+      instance = test_class.new(name: '', age: -1)
+      instance.valid?
+
+      formatter = described_class.new(instance.errors)
+      result = formatter.format
+
+      expect(result).to be_an(Array)
+
+      name_error = result.find { |e| e['pointer'] == '/properties/name' }
+      expect(name_error).to include(
+        'pointer' => '/properties/name',
+        'message' => a_kind_of(String)
+      )
+      expect(name_error['code']).to be_a(String)
+
+      age_error = result.find { |e| e['pointer'] == '/properties/age' }
+      expect(age_error).to include(
+        'pointer' => '/properties/age',
+        'message' => a_kind_of(String)
+      )
+    end
+
+    context 'without error codes' do
+      it 'omits code when include_codes is false' do
+        instance = test_class.new(name: '')
+        instance.valid?
+
+        formatter = described_class.new(instance.errors, include_codes: false)
+        result = formatter.format
+
+        expect(result.first).not_to have_key('code')
+      end
+    end
+  end
+end

--- a/spec/easy_talk/error_formatter/jsonapi_spec.rb
+++ b/spec/easy_talk/error_formatter/jsonapi_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe EasyTalk::ErrorFormatter::Jsonapi do
+  let(:test_class) do
+    Class.new do
+      include EasyTalk::Model
+
+      def self.name = 'JsonapiFormatterTest'
+
+      define_schema do
+        property :name, String, min_length: 2
+        property :age, Integer, minimum: 0
+      end
+    end
+  end
+
+  describe '#format' do
+    it 'formats errors according to JSON:API spec' do
+      instance = test_class.new(name: '', age: -1)
+      instance.valid?
+
+      formatter = described_class.new(instance.errors)
+      result = formatter.format
+
+      expect(result).to be_a(Hash)
+      expect(result['errors']).to be_an(Array)
+      expect(result['errors'].length).to be >= 2 # May include presence errors
+    end
+
+    it 'includes required JSON:API error fields' do
+      instance = test_class.new(name: '')
+      instance.valid?
+
+      formatter = described_class.new(instance.errors)
+      result = formatter.format
+
+      error = result['errors'].first
+      expect(error['status']).to eq('422')
+      expect(error['source']).to be_a(Hash)
+      expect(error['source']['pointer']).to eq('/data/attributes/name')
+      expect(error['title']).to eq('Invalid Attribute')
+      expect(error['detail']).to be_a(String)
+      expect(error['code']).to be_a(String)
+    end
+
+    it 'uses full_message for detail' do
+      instance = test_class.new(name: '')
+      instance.valid?
+
+      formatter = described_class.new(instance.errors)
+      result = formatter.format
+
+      error = result['errors'].first
+      # Full message includes attribute name
+      expect(error['detail']).to match(/name/i)
+    end
+
+    context 'with custom options' do
+      it 'uses custom status' do
+        instance = test_class.new(name: '')
+        instance.valid?
+
+        formatter = described_class.new(instance.errors, status: 400)
+        result = formatter.format
+
+        expect(result['errors'].first['status']).to eq('400')
+      end
+
+      it 'uses custom title' do
+        instance = test_class.new(name: '')
+        instance.valid?
+
+        formatter = described_class.new(instance.errors, title: 'Validation Error')
+        result = formatter.format
+
+        expect(result['errors'].first['title']).to eq('Validation Error')
+      end
+
+      it 'uses custom source prefix' do
+        instance = test_class.new(name: '')
+        instance.valid?
+
+        formatter = described_class.new(instance.errors, source_prefix: '/data')
+        result = formatter.format
+
+        expect(result['errors'].first['source']['pointer']).to eq('/data/name')
+      end
+    end
+
+    context 'without error codes' do
+      it 'omits code when include_codes is false' do
+        instance = test_class.new(name: '')
+        instance.valid?
+
+        formatter = described_class.new(instance.errors, include_codes: false)
+        result = formatter.format
+
+        expect(result['errors'].first).not_to have_key('code')
+      end
+    end
+  end
+end

--- a/spec/easy_talk/error_formatter/path_converter_spec.rb
+++ b/spec/easy_talk/error_formatter/path_converter_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe EasyTalk::ErrorFormatter::PathConverter do
+  describe '.to_json_pointer' do
+    it 'converts simple attribute to JSON Pointer' do
+      expect(described_class.to_json_pointer(:name)).to eq('/properties/name')
+    end
+
+    it 'converts nested attribute to JSON Pointer' do
+      expect(described_class.to_json_pointer('email.address')).to eq('/properties/email/properties/address')
+    end
+
+    it 'converts deeply nested attribute to JSON Pointer' do
+      result = described_class.to_json_pointer('user.profile.settings.theme')
+      expect(result).to eq('/properties/user/properties/profile/properties/settings/properties/theme')
+    end
+
+    it 'accepts symbol input' do
+      expect(described_class.to_json_pointer(:'email.address')).to eq('/properties/email/properties/address')
+    end
+  end
+
+  describe '.to_jsonapi_pointer' do
+    it 'converts simple attribute to JSON:API pointer' do
+      expect(described_class.to_jsonapi_pointer(:name)).to eq('/data/attributes/name')
+    end
+
+    it 'converts nested attribute to JSON:API pointer' do
+      expect(described_class.to_jsonapi_pointer('email.address')).to eq('/data/attributes/email/address')
+    end
+
+    it 'uses custom prefix' do
+      result = described_class.to_jsonapi_pointer(:name, prefix: '/data')
+      expect(result).to eq('/data/name')
+    end
+  end
+
+  describe '.to_flat' do
+    it 'returns attribute as string' do
+      expect(described_class.to_flat(:name)).to eq('name')
+    end
+
+    it 'preserves dot notation' do
+      expect(described_class.to_flat('email.address')).to eq('email.address')
+    end
+  end
+end

--- a/spec/easy_talk/error_formatter/rfc7807_spec.rb
+++ b/spec/easy_talk/error_formatter/rfc7807_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe EasyTalk::ErrorFormatter::Rfc7807 do
+  let(:test_class) do
+    Class.new do
+      include EasyTalk::Model
+
+      def self.name = 'Rfc7807FormatterTest'
+
+      define_schema do
+        property :name, String, min_length: 2
+        property :age, Integer, minimum: 0
+      end
+    end
+  end
+
+  describe '#format' do
+    it 'formats errors as RFC 7807 Problem Details' do
+      instance = test_class.new(name: '', age: -1)
+      instance.valid?
+
+      formatter = described_class.new(instance.errors)
+      result = formatter.format
+
+      expect(result).to be_a(Hash)
+      expect(result['type']).to eq('validation-error')
+      expect(result['title']).to eq('Validation Failed')
+      expect(result['status']).to eq(422)
+      expect(result['detail']).to eq('The request contains invalid parameters')
+      expect(result['errors']).to be_an(Array)
+      expect(result['errors'].length).to be >= 2 # May include presence errors
+    end
+
+    it 'includes pointer and detail in error objects' do
+      instance = test_class.new(name: '')
+      instance.valid?
+
+      formatter = described_class.new(instance.errors)
+      result = formatter.format
+
+      error = result['errors'].first
+      expect(error['pointer']).to eq('/properties/name')
+      expect(error['detail']).to be_a(String)
+      expect(error['code']).to be_a(String)
+    end
+
+    context 'with custom options' do
+      it 'uses custom title' do
+        instance = test_class.new(name: '')
+        instance.valid?
+
+        formatter = described_class.new(instance.errors, title: 'Custom Validation Error')
+        result = formatter.format
+
+        expect(result['title']).to eq('Custom Validation Error')
+      end
+
+      it 'uses custom status' do
+        instance = test_class.new(name: '')
+        instance.valid?
+
+        formatter = described_class.new(instance.errors, status: 400)
+        result = formatter.format
+
+        expect(result['status']).to eq(400)
+      end
+
+      it 'uses custom detail' do
+        instance = test_class.new(name: '')
+        instance.valid?
+
+        formatter = described_class.new(instance.errors, detail: 'Custom detail message')
+        result = formatter.format
+
+        expect(result['detail']).to eq('Custom detail message')
+      end
+
+      it 'uses custom type_base_uri' do
+        instance = test_class.new(name: '')
+        instance.valid?
+
+        formatter = described_class.new(instance.errors, type_base_uri: 'https://api.example.com/errors')
+        result = formatter.format
+
+        expect(result['type']).to eq('https://api.example.com/errors/validation-error')
+      end
+
+      it 'uses custom type' do
+        instance = test_class.new(name: '')
+        instance.valid?
+
+        formatter = described_class.new(instance.errors, type_base_uri: 'https://api.example.com', type: 'invalid-input')
+        result = formatter.format
+
+        expect(result['type']).to eq('https://api.example.com/invalid-input')
+      end
+    end
+
+    context 'with about:blank base URI' do
+      it 'uses type directly without base URI' do
+        instance = test_class.new(name: '')
+        instance.valid?
+
+        formatter = described_class.new(instance.errors, type_base_uri: 'about:blank')
+        result = formatter.format
+
+        expect(result['type']).to eq('validation-error')
+      end
+    end
+  end
+end

--- a/spec/easy_talk/error_formatter_spec.rb
+++ b/spec/easy_talk/error_formatter_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe EasyTalk::ErrorFormatter do
+  let(:address_class) do
+    Class.new do
+      include EasyTalk::Model
+
+      def self.name = 'Address'
+
+      define_schema do
+        property :street, String, min_length: 5
+        property :city, String, min_length: 3
+      end
+    end
+  end
+
+  let(:test_class) do
+    addr_class = address_class
+    Class.new do
+      include EasyTalk::Model
+
+      define_singleton_method(:name) { 'ErrorFormatterTest' }
+
+      define_schema do
+        property :name, String, min_length: 2
+        property :email, String, format: 'email'
+        property :address, addr_class
+      end
+    end
+  end
+
+  describe '.format' do
+    let(:instance) { test_class.new(name: '', email: 'invalid') }
+
+    before { instance.valid? }
+
+    it 'formats errors using the specified format' do
+      result = described_class.format(instance.errors, format: :flat)
+      expect(result).to be_an(Array)
+    end
+
+    it 'uses default format from configuration' do
+      original = EasyTalk.configuration.default_error_format
+      EasyTalk.configuration.default_error_format = :flat
+
+      result = described_class.format(instance.errors)
+      expect(result).to be_an(Array)
+
+      EasyTalk.configuration.default_error_format = original
+    end
+
+    it 'raises ArgumentError for unknown format' do
+      expect do
+        described_class.format(instance.errors, format: :unknown)
+      end.to raise_error(ArgumentError, /Unknown error format: unknown/)
+    end
+
+    it 'passes options to the formatter' do
+      result = described_class.format(instance.errors, format: :rfc7807, title: 'Custom Title')
+      expect(result['title']).to eq('Custom Title')
+    end
+  end
+
+  describe 'InstanceMethods' do
+    let(:instance) { test_class.new(name: '', email: 'invalid') }
+
+    before { instance.valid? }
+
+    describe '#validation_errors' do
+      it 'returns formatted errors using default format' do
+        result = instance.validation_errors
+        expect(result).to be_an(Array)
+      end
+
+      it 'accepts format option' do
+        result = instance.validation_errors(format: :rfc7807)
+        expect(result).to be_a(Hash)
+        expect(result['type']).to be_a(String)
+      end
+
+      it 'passes additional options' do
+        result = instance.validation_errors(format: :rfc7807, title: 'Custom')
+        expect(result['title']).to eq('Custom')
+      end
+    end
+
+    describe '#validation_errors_flat' do
+      it 'returns flat format' do
+        result = instance.validation_errors_flat
+        expect(result).to be_an(Array)
+        expect(result.first).to have_key('field')
+      end
+    end
+
+    describe '#validation_errors_json_pointer' do
+      it 'returns JSON Pointer format' do
+        result = instance.validation_errors_json_pointer
+        expect(result).to be_an(Array)
+        expect(result.first).to have_key('pointer')
+      end
+    end
+
+    describe '#validation_errors_rfc7807' do
+      it 'returns RFC 7807 format' do
+        result = instance.validation_errors_rfc7807
+        expect(result).to be_a(Hash)
+        expect(result).to have_key('type')
+        expect(result).to have_key('title')
+        expect(result).to have_key('status')
+        expect(result).to have_key('errors')
+      end
+
+      it 'accepts options' do
+        result = instance.validation_errors_rfc7807(title: 'User Error', status: 400)
+        expect(result['title']).to eq('User Error')
+        expect(result['status']).to eq(400)
+      end
+    end
+
+    describe '#validation_errors_jsonapi' do
+      it 'returns JSON:API format' do
+        result = instance.validation_errors_jsonapi
+        expect(result).to be_a(Hash)
+        expect(result).to have_key('errors')
+        expect(result['errors'].first).to have_key('source')
+        expect(result['errors'].first).to have_key('status')
+      end
+
+      it 'accepts options' do
+        result = instance.validation_errors_jsonapi(title: 'Validation Error')
+        expect(result['errors'].first['title']).to eq('Validation Error')
+      end
+    end
+  end
+
+  describe 'nested model errors' do
+    # Use valid street but invalid city to trigger nested error propagation
+    # (when all fields are blank, parent reports "can't be blank" instead)
+    let(:instance) { test_class.new(name: 'John', address: { street: 'Main Street', city: 'AB' }) }
+
+    before { instance.valid? }
+
+    it 'formats nested errors with flat paths' do
+      result = instance.validation_errors_flat
+
+      nested_errors = result.select { |e| e['field'].to_s.include?('.') }
+      expect(nested_errors).not_to be_empty
+
+      city_error = result.find { |e| e['field'] == 'address.city' }
+      expect(city_error).to be_present
+    end
+
+    it 'formats nested errors with JSON Pointer paths' do
+      result = instance.validation_errors_json_pointer
+
+      nested_errors = result.select { |e| e['pointer'].include?('/address/') }
+      expect(nested_errors).not_to be_empty
+
+      city_error = result.find { |e| e['pointer'] == '/properties/address/properties/city' }
+      expect(city_error).to be_present
+    end
+
+    it 'formats nested errors with JSON:API paths' do
+      result = instance.validation_errors_jsonapi
+
+      city_error = result['errors'].find { |e| e['source']['pointer'].include?('address') }
+      expect(city_error).to be_present
+      expect(city_error['source']['pointer']).to eq('/data/attributes/address/city')
+    end
+  end
+
+  describe 'configuration' do
+    describe 'default_error_format' do
+      it 'defaults to :flat' do
+        expect(EasyTalk.configuration.default_error_format).to eq(:flat)
+      end
+
+      it 'can be changed' do
+        original = EasyTalk.configuration.default_error_format
+        EasyTalk.configuration.default_error_format = :rfc7807
+        expect(EasyTalk.configuration.default_error_format).to eq(:rfc7807)
+        EasyTalk.configuration.default_error_format = original
+      end
+    end
+
+    describe 'error_type_base_uri' do
+      it 'defaults to "about:blank"' do
+        expect(EasyTalk.configuration.error_type_base_uri).to eq('about:blank')
+      end
+    end
+
+    describe 'include_error_codes' do
+      it 'defaults to true' do
+        expect(EasyTalk.configuration.include_error_codes).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add helper methods to transform ActiveModel validation errors into standardized API-friendly formats for consistent error responses.

## New Features

### Error Formatters
- **Flat format**: Simple array of field/message/code objects
- **JSON Pointer (RFC 6901)**: Paths like `/properties/name`
- **RFC 7807**: Problem Details for HTTP APIs
- **JSON:API**: Standard JSON:API error format

### Instance Methods
All EasyTalk::Model instances now have:
- `validation_errors(format:, **options)` - Uses default or specified format
- `validation_errors_flat(**options)` - Flat array format
- `validation_errors_json_pointer(**options)` - JSON Pointer format
- `validation_errors_rfc7807(**options)` - RFC 7807 Problem Details
- `validation_errors_jsonapi(**options)` - JSON:API format

### Configuration
New configuration options:
- `default_error_format` - Default format (:flat, :json_pointer, :rfc7807, :jsonapi)
- `error_type_base_uri` - Base URI for RFC 7807 type field
- `include_error_codes` - Include semantic error codes in output

### Error Code Mapping
Maps ActiveModel error types to semantic codes:
- :blank → "blank"
- :invalid → "invalid_format"
- :too_short → "too_short"
- :too_long → "too_long"
- :greater_than → "too_small"
- :less_than → "too_large"
- And more...

### Path Conversion
Handles nested model errors with proper path transformation:
- Dot notation: `email.address`
- JSON Pointer: `/properties/email/properties/address`
- JSON:API: `/data/attributes/email/address`

## Files Added
- lib/easy_talk/error_formatter.rb
- lib/easy_talk/error_formatter/base.rb
- lib/easy_talk/error_formatter/error_code_mapper.rb
- lib/easy_talk/error_formatter/path_converter.rb
- lib/easy_talk/error_formatter/flat.rb
- lib/easy_talk/error_formatter/json_pointer.rb
- lib/easy_talk/error_formatter/rfc7807.rb
- lib/easy_talk/error_formatter/jsonapi.rb
- spec/easy_talk/error_formatter_spec.rb
- spec/easy_talk/error_formatter/*.rb (7 test files)

## Files Modified
- lib/easy_talk.rb - Added require for error_formatter
- lib/easy_talk/configuration.rb - Added new config options
- lib/easy_talk/model.rb - Include ErrorFormatter::InstanceMethods

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)