### PR TITLE
feat: implement pluggable type registry (#80)

### DIFF
--- a/lib/easy_talk.rb
+++ b/lib/easy_talk.rb
@@ -15,6 +15,9 @@ module EasyTalk
   require 'easy_talk/validation_adapters/active_model_adapter'
   require 'easy_talk/validation_adapters/none_adapter'
 
+  # Builder registry for pluggable type support
+  require 'easy_talk/builders/registry'
+
   require 'easy_talk/model'
   require 'easy_talk/schema'
   require 'easy_talk/property'
@@ -26,6 +29,43 @@ module EasyTalk
   # Register default validation adapters
   ValidationAdapters::Registry.register(:active_model, ValidationAdapters::ActiveModelAdapter)
   ValidationAdapters::Registry.register(:none, ValidationAdapters::NoneAdapter)
+
+  # Register built-in type builders
+  Builders::Registry.register(String, Builders::StringBuilder)
+  Builders::Registry.register(Integer, Builders::IntegerBuilder)
+  Builders::Registry.register(Float, Builders::NumberBuilder)
+  Builders::Registry.register(BigDecimal, Builders::NumberBuilder)
+  Builders::Registry.register('T::Boolean', Builders::BooleanBuilder)
+  Builders::Registry.register(TrueClass, Builders::BooleanBuilder)
+  Builders::Registry.register(NilClass, Builders::NullBuilder)
+  Builders::Registry.register(Date, Builders::TemporalBuilder::DateBuilder)
+  Builders::Registry.register(DateTime, Builders::TemporalBuilder::DatetimeBuilder)
+  Builders::Registry.register(Time, Builders::TemporalBuilder::TimeBuilder)
+  Builders::Registry.register('anyOf', Builders::CompositionBuilder::AnyOfBuilder, collection: true)
+  Builders::Registry.register('allOf', Builders::CompositionBuilder::AllOfBuilder, collection: true)
+  Builders::Registry.register('oneOf', Builders::CompositionBuilder::OneOfBuilder, collection: true)
+  Builders::Registry.register('T::Types::TypedArray', Builders::TypedArrayBuilder, collection: true)
+  Builders::Registry.register('T::Types::Union', Builders::UnionBuilder, collection: true)
+
+  # Register a custom type with its corresponding schema builder.
+  #
+  # This allows extending EasyTalk with domain-specific types without
+  # modifying the gem's source code.
+  #
+  # @param type_key [Class, String, Symbol] The type to register
+  # @param builder_class [Class] The builder class that generates JSON Schema
+  # @param collection [Boolean] Whether this is a collection type builder
+  #   Collection builders receive (name, type, constraints) instead of (name, constraints)
+  # @return [void]
+  #
+  # @example Register a custom Money type
+  #   EasyTalk.register_type(Money, MoneySchemaBuilder)
+  #
+  # @example Register a collection type
+  #   EasyTalk.register_type(CustomArray, CustomArrayBuilder, collection: true)
+  def self.register_type(type_key, builder_class, collection: false)
+    Builders::Registry.register(type_key, builder_class, collection: collection)
+  end
 
   def self.assert_valid_property_options(property_name, options, *valid_keys)
     valid_keys.flatten!

--- a/lib/easy_talk/builders/registry.rb
+++ b/lib/easy_talk/builders/registry.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+module EasyTalk
+  module Builders
+    # Registry for type-to-builder mappings.
+    #
+    # The registry allows custom types to be registered with their corresponding
+    # schema builder classes at runtime, without modifying the gem's source code.
+    #
+    # Custom registrations take priority over built-in types, allowing users to
+    # override default behavior when needed.
+    #
+    # @example Registering a custom type
+    #   EasyTalk::Builders::Registry.register(Money, MoneySchemaBuilder)
+    #
+    # @example Registering a collection type
+    #   EasyTalk::Builders::Registry.register(CustomArray, CustomArrayBuilder, collection: true)
+    #
+    # @example Resolving a builder for a type
+    #   builder_class, is_collection = EasyTalk::Builders::Registry.resolve(Money)
+    #   builder_class.new(name, constraints).build
+    #
+    class Registry
+      class << self
+        # Get the hash of registered type builders.
+        #
+        # @return [Hash{String => Hash}] The registered builders with metadata
+        def registry
+          @registry ||= {}
+        end
+
+        # Register a type with its corresponding builder class.
+        #
+        # @param type_key [Class, String, Symbol] The type identifier
+        # @param builder_class [Class] The builder class (must respond to .new)
+        # @param collection [Boolean] Whether this is a collection type builder
+        #   Collection builders receive (name, type, constraints) instead of (name, constraints)
+        # @raise [ArgumentError] if the builder does not respond to .new
+        # @return [void]
+        #
+        # @example Register a simple type
+        #   Registry.register(Money, MoneySchemaBuilder)
+        #
+        # @example Register a collection type
+        #   Registry.register(CustomArray, CustomArrayBuilder, collection: true)
+        def register(type_key, builder_class, collection: false)
+          raise ArgumentError, 'Builder must respond to .new' unless builder_class.respond_to?(:new)
+
+          key = normalize_key(type_key)
+          registry[key] = { builder: builder_class, collection: collection }
+        end
+
+        # Resolve a builder for the given type.
+        #
+        # Resolution order:
+        # 1. Check type.class.name (e.g., "T::Types::TypedArray")
+        # 2. Check type.name if type responds to :name (e.g., "String")
+        # 3. Check type itself if it's a Class (e.g., String class)
+        #
+        # @param type [Object] The type to find a builder for
+        # @return [Array(Class, Boolean), nil] A tuple of [builder_class, is_collection] or nil if not found
+        #
+        # @example
+        #   builder_class, is_collection = Registry.resolve(String)
+        #   # => [StringBuilder, false]
+        def resolve(type)
+          entry = find_registration(type)
+          return nil unless entry
+
+          [entry[:builder], entry[:collection]]
+        end
+
+        # Check if a type is registered.
+        #
+        # @param type_key [Class, String, Symbol] The type to check
+        # @return [Boolean] true if the type is registered
+        def registered?(type_key)
+          registry.key?(normalize_key(type_key))
+        end
+
+        # Unregister a type.
+        #
+        # @param type_key [Class, String, Symbol] The type to unregister
+        # @return [Hash, nil] The removed registration or nil if not found
+        def unregister(type_key)
+          registry.delete(normalize_key(type_key))
+        end
+
+        # Get a list of all registered type keys.
+        #
+        # @return [Array<String>] The registered type keys
+        def registered_types
+          registry.keys
+        end
+
+        # Reset the registry to empty state and re-register built-in types.
+        #
+        # @return [void]
+        def reset!
+          @registry = nil
+          register_built_in_types
+        end
+
+        # Register all built-in type builders.
+        # This is called during gem initialization and after reset!
+        #
+        # @return [void]
+        def register_built_in_types
+          register(String, Builders::StringBuilder)
+          register(Integer, Builders::IntegerBuilder)
+          register(Float, Builders::NumberBuilder)
+          register(BigDecimal, Builders::NumberBuilder)
+          register('T::Boolean', Builders::BooleanBuilder)
+          register(TrueClass, Builders::BooleanBuilder)
+          register(NilClass, Builders::NullBuilder)
+          register(Date, Builders::TemporalBuilder::DateBuilder)
+          register(DateTime, Builders::TemporalBuilder::DatetimeBuilder)
+          register(Time, Builders::TemporalBuilder::TimeBuilder)
+          register('anyOf', Builders::CompositionBuilder::AnyOfBuilder, collection: true)
+          register('allOf', Builders::CompositionBuilder::AllOfBuilder, collection: true)
+          register('oneOf', Builders::CompositionBuilder::OneOfBuilder, collection: true)
+          register('T::Types::TypedArray', Builders::TypedArrayBuilder, collection: true)
+          register('T::Types::Union', Builders::UnionBuilder, collection: true)
+        end
+
+        private
+
+        # Normalize a type key to a canonical string form.
+        #
+        # @param type_key [Class, String, Symbol] The type key to normalize
+        # @return [String] The normalized key
+        def normalize_key(type_key)
+          case type_key
+          when Class
+            type_key.name.to_s
+          when Symbol
+            type_key.to_s
+          else
+            type_key.to_s
+          end
+        end
+
+        # Find a registration for the given type.
+        #
+        # Tries multiple resolution strategies in order.
+        #
+        # @param type [Object] The type to find
+        # @return [Hash, nil] The registration entry or nil
+        def find_registration(type)
+          # Strategy 1: Check type.class.name (for Sorbet types like T::Types::TypedArray)
+          class_name = type.class.name.to_s
+          return registry[class_name] if registry.key?(class_name)
+
+          # Strategy 2: Check type.name (for types that respond to :name, like "String")
+          if type.respond_to?(:name)
+            type_name = type.name.to_s
+            return registry[type_name] if registry.key?(type_name)
+          end
+
+          # Strategy 3: Check the type itself if it's a Class
+          return registry[type.name.to_s] if type.is_a?(Class) && registry.key?(type.name.to_s)
+
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/easy_talk/configuration.rb
+++ b/lib/easy_talk/configuration.rb
@@ -38,6 +38,24 @@ module EasyTalk
     def property_naming_strategy=(strategy)
       @property_naming_strategy = EasyTalk::NamingStrategies.derive_strategy(strategy)
     end
+
+    # Register a custom type with its corresponding schema builder.
+    #
+    # This convenience method delegates to Builders::Registry.register
+    # and allows type registration within a configuration block.
+    #
+    # @param type_key [Class, String, Symbol] The type to register
+    # @param builder_class [Class] The builder class that generates JSON Schema
+    # @param collection [Boolean] Whether this is a collection type builder
+    # @return [void]
+    #
+    # @example
+    #   EasyTalk.configure do |config|
+    #     config.register_type Money, MoneySchemaBuilder
+    #   end
+    def register_type(type_key, builder_class, collection: false)
+      EasyTalk::Builders::Registry.register(type_key, builder_class, collection: collection)
+    end
   end
 
   class << self

--- a/spec/easy_talk/builders/custom_type_integration_spec.rb
+++ b/spec/easy_talk/builders/custom_type_integration_spec.rb
@@ -1,0 +1,246 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Custom Type Registration Integration' do
+  # Define a custom Money class
+  let(:money_class) do
+    Class.new do
+      def self.name = 'Money'
+
+      attr_reader :amount, :currency
+
+      def initialize(amount, currency = 'USD')
+        @amount = amount
+        @currency = currency
+      end
+    end
+  end
+
+  # Define a custom builder for Money type
+  let(:money_builder_class) do
+    Class.new(EasyTalk::Builders::BaseBuilder) do
+      def self.name = 'MoneySchemaBuilder'
+
+      def self.valid_options
+        @valid_options ||= {
+          currency: { type: T.nilable(String), key: :currency },
+          min_amount: { type: T.nilable(Numeric), key: :minimum },
+          max_amount: { type: T.nilable(Numeric), key: :maximum }
+        }.freeze
+      end
+
+      def initialize(name, constraints = {})
+        schema = {
+          type: 'object',
+          properties: {
+            amount: { type: 'number' },
+            currency: { type: 'string' }
+          },
+          required: %w[amount currency]
+        }
+        super(name, schema, constraints, self.class.valid_options)
+      end
+    end
+  end
+
+  # Define a GeoPoint builder for testing collection types
+  let(:geo_point_class) do
+    Class.new do
+      def self.name = 'GeoPoint'
+    end
+  end
+
+  let(:geo_point_builder_class) do
+    Class.new(EasyTalk::Builders::BaseBuilder) do
+      def self.name = 'GeoPointBuilder'
+
+      def self.valid_options
+        @valid_options ||= {}.freeze
+      end
+
+      def initialize(name, constraints = {})
+        schema = {
+          type: 'object',
+          properties: {
+            latitude: { type: 'number', minimum: -90, maximum: 90 },
+            longitude: { type: 'number', minimum: -180, maximum: 180 }
+          },
+          required: %w[latitude longitude]
+        }
+        super(name, schema, constraints, self.class.valid_options)
+      end
+    end
+  end
+
+  after do
+    # Clean up custom registrations after each test
+    EasyTalk::Builders::Registry.unregister('Money')
+    EasyTalk::Builders::Registry.unregister('GeoPoint')
+  end
+
+  describe 'registering custom types via EasyTalk.register_type' do
+    before do
+      EasyTalk.register_type(money_class, money_builder_class)
+    end
+
+    it 'allows using custom types in schema definitions' do
+      money_type = money_class
+      test_model = Class.new do
+        include EasyTalk::Model
+
+        def self.name = 'Invoice'
+
+        define_schema do
+          property :total, money_type
+        end
+      end
+
+      schema = test_model.json_schema
+      expect(schema['properties']['total']['type']).to eq('object')
+      expect(schema['properties']['total']['properties']['amount']['type']).to eq('number')
+      expect(schema['properties']['total']['properties']['currency']['type']).to eq('string')
+    end
+
+    it 'supports constraints on custom types' do
+      money_type = money_class
+      test_model = Class.new do
+        include EasyTalk::Model
+
+        def self.name = 'Payment'
+
+        define_schema do
+          property :amount, money_type, description: 'Payment amount'
+        end
+      end
+
+      schema = test_model.json_schema
+      expect(schema['properties']['amount']['description']).to eq('Payment amount')
+    end
+  end
+
+  describe 'registering custom types via configuration block' do
+    before do
+      EasyTalk.configure do |config|
+        config.register_type money_class, money_builder_class
+      end
+    end
+
+    it 'registers the type successfully' do
+      expect(EasyTalk::Builders::Registry.registered?('Money')).to be true
+    end
+
+    it 'allows using the registered type in models' do
+      money_type = money_class
+      test_model = Class.new do
+        include EasyTalk::Model
+
+        def self.name = 'Order'
+
+        define_schema do
+          property :price, money_type
+        end
+      end
+
+      schema = test_model.json_schema
+      expect(schema['properties']['price']['type']).to eq('object')
+    end
+  end
+
+  describe 'overriding built-in types' do
+    let(:custom_string_builder) do
+      Class.new(EasyTalk::Builders::BaseBuilder) do
+        def self.name = 'CustomStringBuilder'
+
+        def self.valid_options
+          @valid_options ||= {}.freeze
+        end
+
+        def initialize(name, constraints = {})
+          schema = { type: 'string', custom: true }
+          super(name, schema, constraints, self.class.valid_options)
+        end
+      end
+    end
+
+    after do
+      # Re-register the original String builder
+      EasyTalk::Builders::Registry.register(String, EasyTalk::Builders::StringBuilder)
+    end
+
+    it 'allows overriding built-in type builders' do
+      EasyTalk.register_type(String, custom_string_builder)
+
+      test_model = Class.new do
+        include EasyTalk::Model
+
+        def self.name = 'CustomStringModel'
+
+        define_schema do
+          property :name, String
+        end
+      end
+
+      schema = test_model.json_schema
+      expect(schema['properties']['name']['custom']).to be true
+    end
+  end
+
+  describe 'multiple custom types' do
+    before do
+      EasyTalk.register_type(money_class, money_builder_class)
+      EasyTalk.register_type(geo_point_class, geo_point_builder_class)
+    end
+
+    it 'supports multiple custom types in a single model' do
+      money_type = money_class
+      geo_type = geo_point_class
+
+      test_model = Class.new do
+        include EasyTalk::Model
+
+        def self.name = 'Store'
+
+        define_schema do
+          property :revenue, money_type
+          property :location, geo_type
+        end
+      end
+
+      schema = test_model.json_schema
+      expect(schema['properties']['revenue']['properties']['amount']['type']).to eq('number')
+      expect(schema['properties']['location']['properties']['latitude']['type']).to eq('number')
+    end
+  end
+
+  describe 'error handling' do
+    it 'raises ArgumentError when registering invalid builder' do
+      invalid_builder = Module.new
+
+      expect do
+        EasyTalk.register_type(money_class, invalid_builder)
+      end.to raise_error(ArgumentError, /Builder must respond to .new/)
+    end
+  end
+
+  describe 'registry management' do
+    it 'can list registered types' do
+      types = EasyTalk::Builders::Registry.registered_types
+      # Check that at least some built-in types are registered
+      expect(types).not_to be_empty
+    end
+
+    it 'can check if a type is registered' do
+      expect(EasyTalk::Builders::Registry.registered?(String)).to be true
+      expect(EasyTalk::Builders::Registry.registered?('NonExistentType')).to be false
+    end
+
+    it 'can unregister a custom type' do
+      EasyTalk.register_type(money_class, money_builder_class)
+      expect(EasyTalk::Builders::Registry.registered?('Money')).to be true
+
+      EasyTalk::Builders::Registry.unregister('Money')
+      expect(EasyTalk::Builders::Registry.registered?('Money')).to be false
+    end
+  end
+end

--- a/spec/easy_talk/builders/registry_spec.rb
+++ b/spec/easy_talk/builders/registry_spec.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe EasyTalk::Builders::Registry do
+  # Create a mock builder class for testing
+  let(:mock_builder_class) do
+    Class.new do
+      def self.name = 'MockBuilder'
+
+      def initialize(*args)
+        @args = args
+      end
+
+      def build
+        { type: 'mock' }
+      end
+    end
+  end
+
+  let(:mock_collection_builder_class) do
+    Class.new do
+      extend EasyTalk::Builders::CollectionHelpers
+
+      def self.name = 'MockCollectionBuilder'
+
+      def initialize(name, type, constraints)
+        @name = name
+        @type = type
+        @constraints = constraints
+      end
+
+      def build
+        { type: 'array', items: { type: 'mock' } }
+      end
+    end
+  end
+
+  # Custom type class for testing
+  let(:custom_type_class) do
+    Class.new do
+      def self.name = 'CustomType'
+    end
+  end
+
+  after do
+    # Reset the registry after each test
+    described_class.reset!
+    # Re-register built-in types that were registered in easy_talk.rb
+    # This is needed because reset! clears everything
+  end
+
+  describe '.register' do
+    it 'registers a builder with a Class type key' do
+      described_class.register(custom_type_class, mock_builder_class)
+      expect(described_class.registered?('CustomType')).to be true
+    end
+
+    it 'registers a builder with a String type key' do
+      described_class.register('CustomString', mock_builder_class)
+      expect(described_class.registered?('CustomString')).to be true
+    end
+
+    it 'registers a builder with a Symbol type key' do
+      described_class.register(:custom_symbol, mock_builder_class)
+      expect(described_class.registered?('custom_symbol')).to be true
+    end
+
+    it 'registers a collection type builder' do
+      described_class.register(custom_type_class, mock_collection_builder_class, collection: true)
+
+      builder_class, is_collection = described_class.resolve(custom_type_class)
+      expect(builder_class).to eq(mock_collection_builder_class)
+      expect(is_collection).to be true
+    end
+
+    it 'raises ArgumentError if builder does not respond to .new' do
+      invalid_builder = Module.new # Modules don't respond to .new
+
+      expect do
+        described_class.register(custom_type_class, invalid_builder)
+      end.to raise_error(ArgumentError, /Builder must respond to .new/)
+    end
+  end
+
+  describe '.resolve' do
+    before do
+      described_class.register(custom_type_class, mock_builder_class)
+    end
+
+    it 'resolves a builder by type class' do
+      builder_class, is_collection = described_class.resolve(custom_type_class)
+      expect(builder_class).to eq(mock_builder_class)
+      expect(is_collection).to be false
+    end
+
+    it 'resolves a builder by instance with class name' do
+      # For Sorbet types, the type's class.name is used
+      type_instance = custom_type_class.new
+      # This won't match because type_instance.class.name is not registered
+      # but if we register with the instance's class name it will work
+      described_class.register(type_instance.class.name, mock_builder_class)
+      builder_class, = described_class.resolve(type_instance)
+      expect(builder_class).to eq(mock_builder_class)
+    end
+
+    it 'returns nil for unregistered types' do
+      unregistered_class = Class.new { def self.name = 'UnregisteredType' }
+      result = described_class.resolve(unregistered_class)
+      expect(result).to be_nil
+    end
+
+    context 'with collection type' do
+      before do
+        described_class.register('CollectionType', mock_collection_builder_class, collection: true)
+      end
+
+      it 'returns is_collection as true' do
+        collection_class = Class.new { def self.name = 'CollectionType' }
+        builder_class, is_collection = described_class.resolve(collection_class)
+        expect(builder_class).to eq(mock_collection_builder_class)
+        expect(is_collection).to be true
+      end
+    end
+  end
+
+  describe '.registered?' do
+    it 'returns true for registered types' do
+      described_class.register('TestType', mock_builder_class)
+      expect(described_class.registered?('TestType')).to be true
+    end
+
+    it 'returns false for unregistered types' do
+      expect(described_class.registered?('NonExistentType')).to be false
+    end
+
+    it 'accepts Class as type key' do
+      described_class.register(custom_type_class, mock_builder_class)
+      expect(described_class.registered?(custom_type_class)).to be true
+    end
+
+    it 'accepts Symbol as type key' do
+      described_class.register(:symbol_type, mock_builder_class)
+      expect(described_class.registered?(:symbol_type)).to be true
+    end
+  end
+
+  describe '.unregister' do
+    before do
+      described_class.register('TypeToRemove', mock_builder_class)
+    end
+
+    it 'removes a registered type' do
+      expect(described_class.registered?('TypeToRemove')).to be true
+      described_class.unregister('TypeToRemove')
+      expect(described_class.registered?('TypeToRemove')).to be false
+    end
+
+    it 'returns the removed registration' do
+      result = described_class.unregister('TypeToRemove')
+      expect(result[:builder]).to eq(mock_builder_class)
+    end
+
+    it 'returns nil for unregistered types' do
+      result = described_class.unregister('NonExistent')
+      expect(result).to be_nil
+    end
+  end
+
+  describe '.registered_types' do
+    before do
+      described_class.register('TypeA', mock_builder_class)
+      described_class.register('TypeB', mock_builder_class)
+    end
+
+    after do
+      described_class.unregister('TypeA')
+      described_class.unregister('TypeB')
+    end
+
+    it 'returns all registered type keys including custom types' do
+      types = described_class.registered_types
+      expect(types).to include('TypeA', 'TypeB')
+      # Also verify built-in types are present
+      expect(types).to include('String', 'Integer')
+    end
+  end
+
+  describe '.reset!' do
+    before do
+      described_class.register('TestType', mock_builder_class)
+    end
+
+    it 'clears all registrations' do
+      expect(described_class.registered?('TestType')).to be true
+      described_class.reset!
+      expect(described_class.registered?('TestType')).to be false
+    end
+  end
+
+  describe 'resolution priority' do
+    let(:original_builder) do
+      Class.new do
+        def self.name = 'OriginalBuilder'
+        def initialize(*); end
+        def build = { type: 'original' }
+      end
+    end
+
+    let(:override_builder) do
+      Class.new do
+        def self.name = 'OverrideBuilder'
+        def initialize(*); end
+        def build = { type: 'override' }
+      end
+    end
+
+    it 'later registrations override earlier ones' do
+      described_class.register('TestType', original_builder)
+      described_class.register('TestType', override_builder)
+
+      builder_class, = described_class.resolve(Class.new { def self.name = 'TestType' })
+      expect(builder_class).to eq(override_builder)
+    end
+  end
+end


### PR DESCRIPTION
Add a Builders::Registry class that enables runtime registration of custom types with their corresponding schema builders. This replaces the hardcoded TYPE_TO_BUILDER frozen hash in property.rb.

Key changes:
- New Builders::Registry class with register, resolve, registered?, unregister, registered_types, and reset! methods
- Registry supports both regular and collection type builders (different constructor signatures)
- Added EasyTalk.register_type convenience method at module level
- Added config.register_type for configuration block registration
- Updated property.rb to use Registry.resolve instead of TYPE_TO_BUILDER
- Built-in types are registered at gem load time

This allows developers to extend EasyTalk with custom types (e.g., Money, GeoPoint) without modifying the gem's source code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)