### PR TITLE
refactor: extract shared schema methods into SchemaMethods mixin (#103)

### DIFF
--- a/lib/easy_talk.rb
+++ b/lib/easy_talk.rb
@@ -7,6 +7,7 @@ module EasyTalk
   require 'easy_talk/errors'
   require 'easy_talk/errors_helper'
   require 'easy_talk/configuration'
+  require 'easy_talk/schema_methods'
   require 'easy_talk/types/composer'
 
   # Validation adapters

--- a/lib/easy_talk/model.rb
+++ b/lib/easy_talk/model.rb
@@ -149,6 +149,8 @@ module EasyTalk
 
     # Module containing class-level methods for defining and accessing the schema of a model.
     module ClassMethods
+      include SchemaMethods
+
       # Returns the schema for the model.
       #
       # @return [Schema] The schema for the model.
@@ -159,71 +161,6 @@ module EasyTalk
                       {}
                     end
       end
-
-      # Returns the reference template for the model.
-      #
-      # @return [String] The reference template for the model.
-      def ref_template
-        "#/$defs/#{name}"
-      end
-
-      # Returns the JSON schema for the model.
-      # This is the final output that includes the $schema keyword if configured.
-      #
-      # @return [Hash] The JSON schema for the model.
-      def json_schema
-        @json_schema ||= build_json_schema
-      end
-
-      private
-
-      # Builds the final JSON schema with optional $schema and $id keywords.
-      def build_json_schema
-        result = schema.as_json
-        schema_uri = resolve_schema_uri
-        id_uri = resolve_schema_id
-
-        # Build prefix hash with $schema and $id (in that order per JSON Schema convention)
-        prefix = {}
-        prefix['$schema'] = schema_uri if schema_uri
-        prefix['$id'] = id_uri if id_uri
-
-        return result if prefix.empty?
-
-        prefix.merge(result)
-      end
-
-      # Resolves the schema URI from per-model setting or global config.
-      def resolve_schema_uri
-        model_version = @schema_definition&.schema&.dig(:schema_version)
-
-        if model_version
-          # Per-model override - :none means explicitly no $schema
-          return nil if model_version == :none
-
-          Configuration::SCHEMA_VERSIONS[model_version] || model_version.to_s
-        else
-          # Fall back to global configuration
-          EasyTalk.configuration.schema_uri
-        end
-      end
-
-      # Resolves the schema ID from per-model setting or global config.
-      def resolve_schema_id
-        model_id = @schema_definition&.schema&.dig(:schema_id)
-
-        if model_id
-          # Per-model override - :none means explicitly no $id
-          return nil if model_id == :none
-
-          model_id.to_s
-        else
-          # Fall back to global configuration
-          EasyTalk.configuration.schema_id
-        end
-      end
-
-      public
 
       # Define the schema for the model using the provided block.
       #

--- a/lib/easy_talk/schema.rb
+++ b/lib/easy_talk/schema.rb
@@ -129,6 +129,8 @@ module EasyTalk
 
     # Class methods for schema-only models.
     module ClassMethods
+      include SchemaMethods
+
       # Returns the schema for the model.
       #
       # @return [Hash] The schema for the model.
@@ -138,20 +140,6 @@ module EasyTalk
                     else
                       {}
                     end
-      end
-
-      # Returns the reference template for the model.
-      #
-      # @return [String] The reference template for the model.
-      def ref_template
-        "#/$defs/#{name}"
-      end
-
-      # Returns the JSON schema for the model.
-      #
-      # @return [Hash] The JSON schema for the model.
-      def json_schema
-        @json_schema ||= build_json_schema
       end
 
       # Define the schema for the model using the provided block.
@@ -204,53 +192,6 @@ module EasyTalk
       # @return [Hash] The built schema.
       def build_schema(schema_definition)
         Builders::ObjectBuilder.new(schema_definition).build
-      end
-
-      # Builds the final JSON schema with optional $schema and $id keywords.
-      #
-      # @return [Hash] The JSON schema.
-      def build_json_schema
-        result = schema.as_json
-        schema_uri = resolve_schema_uri
-        id_uri = resolve_schema_id
-
-        prefix = {}
-        prefix['$schema'] = schema_uri if schema_uri
-        prefix['$id'] = id_uri if id_uri
-
-        return result if prefix.empty?
-
-        prefix.merge(result)
-      end
-
-      # Resolves the schema URI from per-model setting or global config.
-      #
-      # @return [String, nil] The schema URI.
-      def resolve_schema_uri
-        model_version = @schema_definition&.schema&.dig(:schema_version)
-
-        if model_version
-          return nil if model_version == :none
-
-          Configuration::SCHEMA_VERSIONS[model_version] || model_version.to_s
-        else
-          EasyTalk.configuration.schema_uri
-        end
-      end
-
-      # Resolves the schema ID from per-model setting or global config.
-      #
-      # @return [String, nil] The schema ID.
-      def resolve_schema_id
-        model_id = @schema_definition&.schema&.dig(:schema_id)
-
-        if model_id
-          return nil if model_id == :none
-
-          model_id.to_s
-        else
-          EasyTalk.configuration.schema_id
-        end
       end
     end
   end

--- a/lib/easy_talk/schema_methods.rb
+++ b/lib/easy_talk/schema_methods.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module EasyTalk
+  # Shared methods for JSON Schema generation.
+  #
+  # This module provides common functionality for building JSON schemas,
+  # including $schema and $id resolution. It is included in both
+  # EasyTalk::Model and EasyTalk::Schema to avoid code duplication.
+  #
+  # @note Classes including this module must define:
+  #   - `name` - The class name (used in ref_template)
+  #   - `schema` - The built schema hash (used in json_schema)
+  #   - `@schema_definition` - Instance variable with schema metadata
+  #
+  module SchemaMethods
+    # Returns the reference template for the model.
+    #
+    # @return [String] The reference template for the model.
+    def ref_template
+      "#/$defs/#{name}"
+    end
+
+    # Returns the JSON schema for the model.
+    # This is the final output that includes the $schema keyword if configured.
+    #
+    # @return [Hash] The JSON schema for the model.
+    def json_schema
+      @json_schema ||= build_json_schema
+    end
+
+    private
+
+    # Builds the final JSON schema with optional $schema and $id keywords.
+    #
+    # @return [Hash] The JSON schema.
+    def build_json_schema
+      result = schema.as_json
+      schema_uri = resolve_schema_uri
+      id_uri = resolve_schema_id
+
+      prefix = {}
+      prefix['$schema'] = schema_uri if schema_uri
+      prefix['$id'] = id_uri if id_uri
+
+      return result if prefix.empty?
+
+      prefix.merge(result)
+    end
+
+    # Resolves the schema URI from per-model setting or global config.
+    #
+    # @return [String, nil] The schema URI.
+    def resolve_schema_uri
+      model_version = @schema_definition&.schema&.dig(:schema_version)
+
+      if model_version
+        return nil if model_version == :none
+
+        Configuration::SCHEMA_VERSIONS[model_version] || model_version.to_s
+      else
+        EasyTalk.configuration.schema_uri
+      end
+    end
+
+    # Resolves the schema ID from per-model setting or global config.
+    #
+    # @return [String, nil] The schema ID.
+    def resolve_schema_id
+      model_id = @schema_definition&.schema&.dig(:schema_id)
+
+      if model_id
+        return nil if model_id == :none
+
+        model_id.to_s
+      else
+        EasyTalk.configuration.schema_id
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extract duplicated schema-related methods from Model and Schema modules into a shared SchemaMethods module to eliminate code duplication and prevent behavioral drift.

Extracted methods:
- ref_template
- json_schema
- build_json_schema (private)
- resolve_schema_uri (private)
- resolve_schema_id (private)

🤖 Generated with [Claude Code](https://claude.com/claude-code)