### PR TITLE
fix: make ValidationAdapters::Registry.reset! repopulate defaults (#100)

### DIFF
--- a/lib/easy_talk.rb
+++ b/lib/easy_talk.rb
@@ -30,25 +30,10 @@ module EasyTalk
   require 'easy_talk/version'
 
   # Register default validation adapters
-  ValidationAdapters::Registry.register(:active_model, ValidationAdapters::ActiveModelAdapter)
-  ValidationAdapters::Registry.register(:none, ValidationAdapters::NoneAdapter)
+  ValidationAdapters::Registry.register_default_adapters
 
   # Register built-in type builders
-  Builders::Registry.register(String, Builders::StringBuilder)
-  Builders::Registry.register(Integer, Builders::IntegerBuilder)
-  Builders::Registry.register(Float, Builders::NumberBuilder)
-  Builders::Registry.register(BigDecimal, Builders::NumberBuilder)
-  Builders::Registry.register('T::Boolean', Builders::BooleanBuilder)
-  Builders::Registry.register(TrueClass, Builders::BooleanBuilder)
-  Builders::Registry.register(NilClass, Builders::NullBuilder)
-  Builders::Registry.register(Date, Builders::TemporalBuilder::DateBuilder)
-  Builders::Registry.register(DateTime, Builders::TemporalBuilder::DatetimeBuilder)
-  Builders::Registry.register(Time, Builders::TemporalBuilder::TimeBuilder)
-  Builders::Registry.register('anyOf', Builders::CompositionBuilder::AnyOfBuilder, collection: true)
-  Builders::Registry.register('allOf', Builders::CompositionBuilder::AllOfBuilder, collection: true)
-  Builders::Registry.register('oneOf', Builders::CompositionBuilder::OneOfBuilder, collection: true)
-  Builders::Registry.register('T::Types::TypedArray', Builders::TypedArrayBuilder, collection: true)
-  Builders::Registry.register('T::Types::Union', Builders::UnionBuilder, collection: true)
+  Builders::Registry.register_built_in_types
 
   # Register a custom type with its corresponding schema builder.
   #

--- a/lib/easy_talk/validation_adapters/registry.rb
+++ b/lib/easy_talk/validation_adapters/registry.rb
@@ -65,10 +65,21 @@ module EasyTalk
         end
 
         # Reset the registry (useful for testing).
+        # Re-registers the default adapters after clearing.
         #
         # @return [void]
         def reset!
           @adapters = nil
+          register_default_adapters
+        end
+
+        # Register the default validation adapters.
+        # This is called during gem initialization and after reset!
+        #
+        # @return [void]
+        def register_default_adapters
+          register(:active_model, ActiveModelAdapter)
+          register(:none, NoneAdapter)
         end
       end
     end


### PR DESCRIPTION
- Add register_default_adapters method to centralize default adapter registration
- Update reset! to call register_default_adapters after clearing
- Update easy_talk.rb to use register_default_adapters instead of inline registrations
- Also use Builders::Registry.register_built_in_types (from #102)
- Update tests to reflect new reset! behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)