### PR TITLE
fix: avoid mutating VALID_OPTIONS constant in TypedArrayBuilder (#99)

### DIFF
--- a/lib/easy_talk/builders/typed_array_builder.rb
+++ b/lib/easy_talk/builders/typed_array_builder.rb
@@ -24,11 +24,18 @@ module EasyTalk
       def initialize(name, type, constraints = {})
         @name = name
         @type = type
+        @valid_options = deep_dup_options(VALID_OPTIONS)
         update_option_types
-        super(name, { type: 'array' }, constraints, VALID_OPTIONS)
+        super(name, { type: 'array' }, constraints, @valid_options)
       end
 
       private
+
+      # Creates a copy of options with duped nested hashes to avoid mutating the constant.
+      sig { params(options: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+      def deep_dup_options(options)
+        options.transform_values(&:dup)
+      end
 
       # Modifies the schema to include the `items` property.
       #
@@ -55,8 +62,8 @@ module EasyTalk
       sig { void }
       # Updates the option types for the array builder.
       def update_option_types
-        VALID_OPTIONS[:enum][:type] = T::Array[inner_type]
-        VALID_OPTIONS[:const][:type] = T::Array[inner_type]
+        @valid_options[:enum][:type] = T::Array[inner_type]
+        @valid_options[:const][:type] = T::Array[inner_type]
       end
     end
   end

--- a/spec/easy_talk/builders/typed_array_builder_spec.rb
+++ b/spec/easy_talk/builders/typed_array_builder_spec.rb
@@ -113,4 +113,20 @@ RSpec.describe EasyTalk::Builders::TypedArrayBuilder do
       end.to raise_error(EasyTalk::ConstraintError, "Error in property 'name': Constraint 'enum' at index 0 expects Integer, but received \"one\" (String).")
     end
   end
+
+  context 'with multiple inner types' do
+    it 'does not mutate VALID_OPTIONS across instances' do
+      original_enum_type = described_class::VALID_OPTIONS[:enum][:type]
+      original_const_type = described_class::VALID_OPTIONS[:const][:type]
+
+      # Build with String inner type
+      described_class.new(:strings, T::Array[String], enum: %w[a b]).build
+      # Build with Integer inner type
+      described_class.new(:integers, T::Array[Integer], enum: [1, 2]).build
+
+      # VALID_OPTIONS should remain unchanged
+      expect(described_class::VALID_OPTIONS[:enum][:type]).to eq(original_enum_type)
+      expect(described_class::VALID_OPTIONS[:const][:type]).to eq(original_const_type)
+    end
+  end
 end


### PR DESCRIPTION
- Add deep_dup_options method to create instance-level copy of options
- Use @valid_options instance variable instead of mutating the constant
- Add test verifying VALID_OPTIONS remains unchanged across instances

This prevents type information from "bleeding" across different TypedArrayBuilder instances when building arrays with different inner types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)