### PR TITLE
fix: fail fast on unknown property types instead of returning 'object…

### DIFF
--- a/lib/easy_talk/errors.rb
+++ b/lib/easy_talk/errors.rb
@@ -4,5 +4,6 @@ module EasyTalk
   class Error < StandardError; end
   class ConstraintError < Error; end
   class UnknownOptionError < Error; end
+  class UnknownTypeError < Error; end
   class InvalidPropertyNameError < Error; end
 end

--- a/lib/easy_talk/property.rb
+++ b/lib/easy_talk/property.rb
@@ -113,7 +113,9 @@ module EasyTalk
         # e.g. :title, :description, :default, etc
         type.schema.merge!(constraints)
       else
-        'object'
+        raise UnknownTypeError,
+              "Unknown type '#{type.inspect}' for property '#{name}'. " \
+              'Register a custom builder with EasyTalk.register_type or use a supported type.'
       end
     end
 

--- a/spec/easy_talk/property_spec.rb
+++ b/spec/easy_talk/property_spec.rb
@@ -94,6 +94,15 @@ RSpec.describe EasyTalk::Property do
     end
   end
 
+  context 'with an unknown type' do
+    it 'raises UnknownTypeError' do
+      unknown_type = Class.new
+      expect do
+        described_class.new(:field, unknown_type).build
+      end.to raise_error(EasyTalk::UnknownTypeError, /Unknown type.*for property 'field'/)
+    end
+  end
+
   # unsure if this should be supported
   context 'with a model' do
     let(:custom_class) do


### PR DESCRIPTION
…' (#97)

Previously, when a property type couldn't be resolved to a builder and didn't have a schema method, the code silently returned 'object'. This allowed typos like `Stirng` instead of `String` to go unnoticed.

Now raises UnknownTypeError with a descriptive message that includes the type and property name, plus guidance to register a custom builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)