### PR TITLE
fix: avoid mutating schema definition during property building (#95)

### DIFF
--- a/spec/easy_talk/builders/object_builder_spec.rb
+++ b/spec/easy_talk/builders/object_builder_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe EasyTalk::Builders::ObjectBuilder do
+  describe 'schema immutability' do
+    let(:model) do
+      Class.new do
+        include EasyTalk::Model
+
+        def self.name
+          'TestModel'
+        end
+
+        define_schema do
+          property :name, String, as: :full_name
+          property :age, Integer
+        end
+      end
+    end
+
+    it 'does not mutate the original schema definition when building' do
+      schema_definition = model.schema_definition
+      original_constraints = schema_definition.schema[:properties][:name][:constraints].dup
+
+      # Build the schema multiple times
+      described_class.new(schema_definition).build
+      described_class.new(schema_definition).build
+
+      # The original constraints should remain unchanged
+      expect(schema_definition.schema[:properties][:name][:constraints]).to eq(original_constraints)
+    end
+
+    it 'preserves the :as constraint in the original schema after building' do
+      schema_definition = model.schema_definition
+
+      # Build the schema
+      described_class.new(schema_definition).build
+
+      # The :as constraint should still be present
+      expect(schema_definition.schema[:properties][:name][:constraints][:as]).to eq(:full_name)
+    end
+
+    it 'produces consistent JSON schema across multiple builds' do
+      # Using model.json_schema calls the builder internally
+      first_json = model.json_schema
+      # Reset the cached schema to force rebuild
+      model.instance_variable_set(:@schema, nil)
+      model.instance_variable_set(:@json_schema, nil)
+      second_json = model.json_schema
+
+      expect(first_json).to eq(second_json)
+    end
+  end
+end


### PR DESCRIPTION
The ObjectBuilder was mutating the original schema definition in two ways:

1. Shallow dup on line 38 didn't protect nested structures. When `String.dup` is called, Ruby creates an anonymous subclass instead of returning the String class itself, corrupting type information.

2. Destructive `delete(:as)` on line 104 was modifying the original constraints hash, causing side effects across multiple builds.

Changes:
- Add `deep_dup` method that recursively duplicates nested hashes and arrays while preserving Class and Module objects (which represent types and should not be duplicated)
- Replace shallow `schema.dup` with `deep_dup(schema)` for proper deep cloning of the schema definition
- Replace destructive `constraints.delete(:as)` with non-mutating access `constraints[:as] || original_name`
- Add `:as` to excluded constraints in `build_property` to prevent it from being passed to Property construction
- Add spec file with tests for schema immutability

🤖 Generated with [Claude Code](https://claude.com/claude-code)