### PR TITLE
fix: validate nested EasyTalk::Model objects in arrays (#112)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -114,3 +114,7 @@ Lint/DuplicateBranch:
 
 Gemspec/DevelopmentDependencies:
   Enabled: false
+
+Naming/PredicateMethod:
+  Exclude:
+    - spec/support/schema_validation_matcher.rb

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'json_schemer', '>= 2.0'
 gem 'pry-byebug', '>= 3.10'
 gem 'rake', '>= 13.1'
 gem 'rspec', '>= 3.0'

--- a/spec/easy_talk/schema_validation_matcher_spec.rb
+++ b/spec/easy_talk/schema_validation_matcher_spec.rb
@@ -1,0 +1,292 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Schema Validation Matcher' do
+  let(:address_class) do
+    Class.new do
+      include EasyTalk::Model
+
+      def self.name
+        'Address'
+      end
+
+      define_schema do
+        property :street, String
+        property :city, String
+        property :state, String
+        property :zip, String
+      end
+    end
+  end
+
+  let(:employee_class) do
+    address = address_class
+    Class.new do
+      include EasyTalk::Model
+
+      def self.name
+        'Employee'
+      end
+
+      define_schema do
+        property :name, String
+        property :gender, String, enum: %w[male female other]
+        property :department, T.nilable(String)
+        property :active, T::Boolean, default: true
+        property :addresses, T.nilable(T::Array[address])
+      end
+    end
+  end
+
+  before do
+    stub_const('Address', address_class)
+    stub_const('Employee', employee_class)
+  end
+
+  describe 'validate_schema_for matcher' do
+    context 'with valid data' do
+      it 'passes when data matches schema' do
+        expect(Employee).to validate_schema_for(
+          name: 'John Doe',
+          gender: 'male',
+          department: 'Engineering',
+          active: true,
+          addresses: [
+            { street: '123 Main St', city: 'Boston', state: 'MA', zip: '02101' }
+          ]
+        )
+      end
+
+      it 'passes with nil for nilable properties' do
+        expect(Employee).to validate_schema_for(
+          name: 'Jane Doe',
+          gender: 'female',
+          department: nil,
+          active: true,
+          addresses: nil
+        )
+      end
+
+      it 'passes with empty array for array properties' do
+        expect(Employee).to validate_schema_for(
+          name: 'Bob Smith',
+          gender: 'male',
+          department: nil,
+          active: false,
+          addresses: []
+        )
+      end
+    end
+
+    context 'with invalid data' do
+      it 'fails when enum value is invalid' do
+        expect(Employee).not_to validate_schema_for(
+          name: 'Invalid Gender',
+          gender: 'invalid_value',
+          department: nil,
+          active: true,
+          addresses: nil
+        )
+      end
+
+      it 'fails when required field is missing' do
+        expect(Employee).not_to validate_schema_for(
+          gender: 'male',
+          department: nil,
+          active: true,
+          addresses: nil
+        )
+      end
+
+      it 'fails when boolean field has wrong type' do
+        expect(Employee).not_to validate_schema_for(
+          name: 'Test',
+          gender: 'male',
+          department: nil,
+          active: 'not_a_boolean',
+          addresses: nil
+        )
+      end
+
+      it 'fails when array contains wrong type' do
+        expect(Employee).not_to validate_schema_for(
+          name: 'Test',
+          gender: 'male',
+          department: nil,
+          active: true,
+          addresses: ['not an object']
+        )
+      end
+    end
+  end
+
+  describe 'have_matching_validations_for matcher' do
+    context 'when validations agree' do
+      it 'passes for valid data' do
+        expect(Employee).to have_matching_validations_for(
+          name: 'John Doe',
+          gender: 'male',
+          department: 'Engineering',
+          active: true,
+          addresses: nil
+        )
+      end
+
+      it 'passes for invalid enum value' do
+        expect(Employee).to have_matching_validations_for(
+          name: 'Jane Doe',
+          gender: 'invalid_gender',
+          department: nil,
+          active: true,
+          addresses: nil
+        )
+      end
+
+      it 'passes for nil boolean (both catch it)' do
+        expect(Employee).to have_matching_validations_for(
+          name: 'Test User',
+          gender: 'male',
+          department: nil,
+          active: nil,
+          addresses: nil
+        )
+      end
+    end
+
+    context 'when validations disagree (known gaps)', :known_gap do
+      it 'detects mismatch for empty string (schema valid, ActiveModel invalid)' do
+        # JSON Schema type: "string" allows empty strings
+        # ActiveModel presence: true rejects empty strings
+        expect(Employee).not_to have_matching_validations_for(
+          name: '',
+          gender: 'male',
+          department: nil,
+          active: true,
+          addresses: nil
+        )
+      end
+
+      it 'detects mismatch for array with wrong type (schema invalid, ActiveModel valid)' do
+        # JSON Schema catches type mismatch in array items
+        # ActiveModel doesn't validate array item types for T.nilable(T::Array[Model])
+        expect(Employee).not_to have_matching_validations_for(
+          name: 'Test',
+          gender: 'male',
+          department: nil,
+          active: true,
+          addresses: ['not an object']
+        )
+      end
+    end
+  end
+
+  describe 'schema_validation_result helper' do
+    it 'provides detailed validation information' do
+      result = schema_validation_result(Employee, {
+                                          name: 'Test',
+                                          gender: 'invalid',
+                                          department: nil,
+                                          active: true,
+                                          addresses: nil
+                                        })
+
+      expect(result.schema_valid?).to be false
+      expect(result.schema_error_pointers).to include('/gender')
+      expect(result.schema_error_types).to include('enum')
+
+      expect(result.active_model_valid?).to be false
+      expect(result.active_model_error_attributes).to include(:gender)
+    end
+
+    it 'provides formatted errors for API responses' do
+      result = schema_validation_result(Employee, {
+                                          name: '',
+                                          gender: 'invalid',
+                                          department: nil,
+                                          active: nil,
+                                          addresses: nil
+                                        })
+
+      formatted = result.formatted_errors
+      expect(formatted).to be_an(Array)
+      expect(formatted.first).to include('field', 'message')
+    end
+
+    it 'exposes validations_match? for checking alignment' do
+      # Valid data - both should agree
+      valid_result = schema_validation_result(Employee, {
+                                                name: 'John',
+                                                gender: 'male',
+                                                department: nil,
+                                                active: true,
+                                                addresses: nil
+                                              })
+      expect(valid_result.validations_match?).to be true
+
+      # Invalid enum - both should agree
+      invalid_result = schema_validation_result(Employee, {
+                                                  name: 'John',
+                                                  gender: 'invalid',
+                                                  department: nil,
+                                                  active: true,
+                                                  addresses: nil
+                                                })
+      expect(invalid_result.validations_match?).to be true
+    end
+  end
+
+  describe 'nested model validation in arrays' do
+    context 'T.nilable(T::Array[Model]) with invalid nested data' do
+      let(:invalid_nested_data) do
+        {
+          name: 'Test User',
+          gender: 'male',
+          department: nil,
+          active: true,
+          addresses: [
+            { street: '', city: '', state: '', zip: '' }
+          ]
+        }
+      end
+
+      it 'JSON Schema considers empty nested object fields valid (no minLength constraint)' do
+        # JSON Schema type: "string" allows empty strings - this is expected behavior
+        expect(Employee).to validate_schema_for(invalid_nested_data)
+      end
+
+      it 'ActiveModel now validates nested models in arrays (issue #112 fixed)' do
+        # Issue #112 is now fixed - nested models in arrays are recursively validated
+        employee = Employee.new(invalid_nested_data)
+        expect(employee.valid?).to be false
+        expect(employee.errors.attribute_names).to include(:'addresses[0].street')
+        expect(employee.errors.attribute_names).to include(:'addresses[0].city')
+      end
+
+      it 'validators now disagree on empty strings (semantic difference)', :known_gap do
+        # JSON Schema allows empty strings (type: "string")
+        # ActiveModel rejects empty strings (presence: true)
+        # This is a known semantic difference, not a bug
+        expect(Employee).not_to have_matching_validations_for(invalid_nested_data)
+      end
+    end
+
+    context 'with valid nested data' do
+      let(:valid_nested_data) do
+        {
+          name: 'Test User',
+          gender: 'male',
+          department: nil,
+          active: true,
+          addresses: [
+            { street: '123 Main St', city: 'Boston', state: 'MA', zip: '02101' }
+          ]
+        }
+      end
+
+      it 'both validators agree valid data is valid' do
+        expect(Employee).to have_matching_validations_for(valid_nested_data)
+      end
+    end
+  end
+end

--- a/spec/easy_talk/validations_spec.rb
+++ b/spec/easy_talk/validations_spec.rb
@@ -127,7 +127,9 @@ RSpec.describe 'Auto Validations' do
       expect(user.errors[:email]).to include("can't be blank")
       expect(user.errors[:age]).to include("can't be blank")
       expect(user.errors[:gender]).to include("can't be blank")
-      expect(user.errors[:tags]).to include("can't be blank")
+      # Arrays skip presence validation (empty arrays are valid)
+      # Use min_items constraint to require non-empty arrays
+      expect(user.errors[:tags]).to include('is too short (minimum is 1 character)')
       expect(user.errors[:active]).to include("can't be blank")
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,9 @@ require 'easy_talk'
 require 'pry-byebug'
 require 'rspec/json_expectations'
 
+# Load support files
+Dir[File.join(__dir__, 'support', '**', '*.rb')].each { |f| require f }
+
 RSpec.configure do |config|
   config.example_status_persistence_file_path = '.rspec_status'
 

--- a/spec/support/schema_validation_matcher.rb
+++ b/spec/support/schema_validation_matcher.rb
@@ -1,0 +1,325 @@
+# frozen_string_literal: true
+
+require 'json_schemer'
+
+module EasyTalk
+  module RSpec
+    # Custom RSpec matcher that validates data against an EasyTalk model's JSON Schema
+    # using json_schemer, then compares with ActiveModel validation results.
+    #
+    # @example Basic usage - validate data matches schema
+    #   expect(User).to validate_schema_for(name: "John", email: "john@example.com")
+    #
+    # @example Expect schema validation to fail
+    #   expect(User).not_to validate_schema_for(name: "", email: "invalid")
+    #
+    # @example Check that ActiveModel and JSON Schema validations agree
+    #   expect(User).to have_matching_validations_for(name: "John", email: "john@example.com")
+    #
+    class SchemaValidationMatcher
+      def initialize(data)
+        @data = data
+        @schema_errors = []
+        @model_instance = nil
+      end
+
+      def matches?(model_class)
+        @model_class = model_class
+        @schema = model_class.json_schema
+        @schemer = JSONSchemer.schema(@schema)
+
+        # Validate against JSON Schema
+        normalized_data = normalize_data(@data)
+        @schema_errors = @schemer.validate(normalized_data).to_a
+
+        @schema_errors.empty?
+      end
+
+      def failure_message
+        error_details = @schema_errors.map do |error|
+          "  - #{error['data_pointer']}: #{error['type']} (#{error['error']})"
+        end.join("\n")
+
+        "expected #{@model_class} schema to validate data:\n#{@data.inspect}\n\n" \
+          "but got schema errors:\n#{error_details}"
+      end
+
+      def failure_message_when_negated
+        "expected #{@model_class} schema to reject data:\n#{@data.inspect}\n\n" \
+          'but it was valid'
+      end
+
+      private
+
+      def normalize_data(data)
+        case data
+        when Hash
+          data.transform_keys(&:to_s).transform_values { |v| normalize_data(v) }
+        when Array
+          data.map { |v| normalize_data(v) }
+        else
+          data
+        end
+      end
+    end
+
+    # Matcher that checks if ActiveModel validations and JSON Schema validations agree
+    class MatchingValidationsMatcher
+      ValidationResult = Struct.new(:valid, :errors, keyword_init: true)
+
+      def initialize(data)
+        @data = data
+        @schema_result = nil
+        @active_model_result = nil
+        @mismatches = []
+      end
+
+      def matches?(model_class)
+        @model_class = model_class
+
+        @schema_result = validate_with_schema(model_class)
+        @active_model_result = validate_with_active_model(model_class)
+
+        analyze_mismatches
+
+        @schema_result.valid == @active_model_result.valid && @mismatches.empty?
+      end
+
+      def failure_message
+        build_comparison_message('to have matching validations')
+      end
+
+      def failure_message_when_negated
+        build_comparison_message('to have mismatching validations')
+      end
+
+      private
+
+      def validate_with_schema(model_class)
+        schema = model_class.json_schema
+        schemer = JSONSchemer.schema(schema)
+        errors = schemer.validate(normalize_data(@data)).to_a
+
+        ValidationResult.new(
+          valid: errors.empty?,
+          errors: errors.map { |e| format_schema_error(e) }
+        )
+      end
+
+      def validate_with_active_model(model_class)
+        instance = model_class.new(@data)
+        valid = instance.valid?
+
+        ValidationResult.new(
+          valid: valid,
+          errors: instance.errors.map { |e| { attribute: e.attribute.to_s, message: e.message, type: e.type } }
+        )
+      end
+
+      def format_schema_error(error)
+        {
+          pointer: error['data_pointer'],
+          type: error['type'],
+          details: error['error']
+        }
+      end
+
+      def analyze_mismatches
+        @mismatches = []
+
+        if @schema_result.valid != @active_model_result.valid
+          @mismatches << {
+            type: :validity_mismatch,
+            schema_valid: @schema_result.valid,
+            active_model_valid: @active_model_result.valid
+          }
+        end
+
+        # Check for errors that exist in one but not the other
+        analyze_error_coverage
+      end
+
+      def analyze_error_coverage
+        schema_error_paths = @schema_result.errors.map { |e| e[:pointer] }.compact
+        active_model_attrs = @active_model_result.errors.map { |e| e[:attribute] }
+
+        # Schema errors not covered by ActiveModel
+        schema_error_paths.each do |path|
+          attr = path_to_attribute(path)
+          next if active_model_attrs.any? { |a| a == attr || a.start_with?("#{attr}.") || a.start_with?("#{attr}[") }
+
+          @mismatches << { type: :schema_only, path: path, attribute: attr }
+        end
+      end
+
+      def path_to_attribute(pointer)
+        pointer.gsub(%r{^/}, '').gsub('/', '.')
+      end
+
+      def build_comparison_message(expectation)
+        msg = ["expected #{@model_class} #{expectation} for data:", @data.inspect, '']
+
+        msg << 'JSON Schema validation:'
+        msg << "  Valid: #{@schema_result.valid}"
+        if @schema_result.errors.any?
+          msg << '  Errors:'
+          @schema_result.errors.each { |e| msg << "    - #{e[:pointer]}: #{e[:type]}" }
+        end
+
+        msg << ''
+        msg << 'ActiveModel validation:'
+        msg << "  Valid: #{@active_model_result.valid}"
+        if @active_model_result.errors.any?
+          msg << '  Errors:'
+          @active_model_result.errors.each { |e| msg << "    - #{e[:attribute]}: #{e[:message]}" }
+        end
+
+        if @mismatches.any?
+          msg << ''
+          msg << 'Mismatches detected:'
+          @mismatches.each do |m|
+            case m[:type]
+            when :validity_mismatch
+              msg << "  - Validity differs: Schema=#{m[:schema_valid]}, ActiveModel=#{m[:active_model_valid]}"
+            when :schema_only
+              msg << "  - Schema error not caught by ActiveModel: #{m[:path]}"
+            when :active_model_only
+              msg << "  - ActiveModel error not in schema: #{m[:attribute]}"
+            end
+          end
+        end
+
+        msg.join("\n")
+      end
+
+      def normalize_data(data)
+        case data
+        when Hash
+          data.transform_keys(&:to_s).transform_values { |v| normalize_data(v) }
+        when Array
+          data.map { |v| normalize_data(v) }
+        else
+          data
+        end
+      end
+    end
+
+    # Detailed schema validation result for debugging and assertions
+    class SchemaValidationResult
+      attr_reader :model_class, :data, :schema, :schema_errors, :model_instance
+
+      def initialize(model_class, data)
+        @model_class = model_class
+        @data = data
+        @schema = model_class.json_schema
+        @schemer = JSONSchemer.schema(@schema)
+
+        perform_validation
+      end
+
+      def schema_valid?
+        @schema_errors.empty?
+      end
+
+      def active_model_valid?
+        @model_instance.valid?
+      end
+
+      def validations_match?
+        schema_valid? == active_model_valid?
+      end
+
+      def schema_error_pointers
+        @schema_errors.map { |e| e['data_pointer'] }
+      end
+
+      def schema_error_types
+        @schema_errors.map { |e| e['type'] }
+      end
+
+      def active_model_error_attributes
+        @model_instance.errors.map(&:attribute)
+      end
+
+      def active_model_error_messages
+        @model_instance.errors.full_messages
+      end
+
+      def formatted_errors
+        @model_instance.validation_errors_flat
+      end
+
+      def to_h
+        {
+          schema_valid: schema_valid?,
+          schema_errors: @schema_errors.map { |e| { pointer: e['data_pointer'], type: e['type'] } },
+          active_model_valid: active_model_valid?,
+          active_model_errors: @model_instance.errors.to_a.map { |e| { attribute: e.attribute, message: e.message } },
+          formatted_errors: formatted_errors,
+          validations_match: validations_match?
+        }
+      end
+
+      private
+
+      def perform_validation
+        normalized = normalize_data(@data)
+        @schema_errors = @schemer.validate(normalized).to_a
+        @model_instance = @model_class.new(@data)
+        @model_instance.valid?
+      end
+
+      def normalize_data(data)
+        case data
+        when Hash
+          data.transform_keys(&:to_s).transform_values { |v| normalize_data(v) }
+        when Array
+          data.map { |v| normalize_data(v) }
+        else
+          data
+        end
+      end
+    end
+  end
+end
+
+# RSpec matcher DSL methods
+module EasyTalk
+  module RSpec
+    module Matchers
+      # Validates that data passes JSON Schema validation for a model
+      #
+      # @example
+      #   expect(User).to validate_schema_for(name: "John", age: 30)
+      #   expect(User).not_to validate_schema_for(name: "", age: -1)
+      #
+      def validate_schema_for(data)
+        SchemaValidationMatcher.new(data)
+      end
+
+      # Validates that ActiveModel and JSON Schema validations produce the same result
+      #
+      # @example
+      #   expect(User).to have_matching_validations_for(name: "John", age: 30)
+      #
+      def have_matching_validations_for(data)
+        MatchingValidationsMatcher.new(data)
+      end
+
+      # Helper to get detailed validation results for debugging
+      #
+      # @example
+      #   result = schema_validation_result(User, { name: "", age: -1 })
+      #   expect(result.schema_valid?).to be false
+      #   expect(result.schema_error_pointers).to include("/name")
+      #
+      def schema_validation_result(model_class, data)
+        SchemaValidationResult.new(model_class, data)
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include EasyTalk::RSpec::Matchers
+end


### PR DESCRIPTION
Previously, when using `T::Array[Model]` or `T.nilable(T::Array[Model])`, nested EasyTalk::Model objects within arrays were not validated. The `apply_array_item_type_validation` method only checked if items were instances of the correct type but never called `valid?` on nested model instances.

This commit fixes the issue by:

1. **Recursive validation of nested models in arrays**
   - Extended `apply_array_item_type_validation` in ActiveModelAdapter to call `valid?` on each array item that is an EasyTalk::Model
   - Errors from nested models are merged with indexed paths (e.g., `addresses[0].street`)

2. **Auto-instantiation of hash items in arrays**
   - Added `instantiate_array_items` method in Model#initialize to convert hash items to model instances for T::Array[Model] properties
   - Refactored initialize to reduce cyclomatic complexity

3. **Fixed type extraction for nilable arrays**
   - Updated `extract_inner_type` in Base adapter to properly handle `T.nilable(T::Array[Model])` by returning TypedArray directly
   - Fixed type detection to use `T::Types::TypedArray` instead of checking for `type_parameter` method

4. **Array presence validation behavior**
   - Arrays now skip presence validation (empty arrays are valid)
   - Use `min_items: 1` constraint if non-empty arrays are required

5. **Added json_schemer for systematic validation testing**
   - Added custom RSpec matchers: `validate_schema_for` and `have_matching_validations_for`
   - These matchers compare JSON Schema validation with ActiveModel validation to identify discrepancies

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)