### PR TITLE
Add test coverage for core lib/easy_talk files

### DIFF
--- a/spec/easy_talk/configuration_spec.rb
+++ b/spec/easy_talk/configuration_spec.rb
@@ -21,6 +21,120 @@ RSpec.describe EasyTalk::Configuration do
     it 'defaults property_naming_strategy to identity' do
       expect(config.property_naming_strategy).to eq(EasyTalk::NamingStrategies::IDENTITY)
     end
+
+    it 'defaults validation_adapter to :active_model' do
+      expect(config.validation_adapter).to eq(:active_model)
+    end
+
+    it 'defaults schema_version to :none' do
+      expect(config.schema_version).to eq(:none)
+    end
+
+    it 'defaults schema_id to nil' do
+      expect(config.schema_id).to be_nil
+    end
+
+    it 'defaults use_refs to false' do
+      expect(config.use_refs).to be false
+    end
+
+    it 'defaults default_error_format to :flat' do
+      expect(config.default_error_format).to eq(:flat)
+    end
+
+    it 'defaults error_type_base_uri to about:blank' do
+      expect(config.error_type_base_uri).to eq('about:blank')
+    end
+
+    it 'defaults include_error_codes to true' do
+      expect(config.include_error_codes).to be true
+    end
+  end
+
+  describe '#schema_uri' do
+    subject(:config) { described_class.new }
+
+    it 'returns nil when schema_version is :none' do
+      config.schema_version = :none
+      expect(config.schema_uri).to be_nil
+    end
+
+    it 'returns draft 2020-12 URI' do
+      config.schema_version = :draft202012
+      expect(config.schema_uri).to eq('https://json-schema.org/draft/2020-12/schema')
+    end
+
+    it 'returns draft 2019-09 URI' do
+      config.schema_version = :draft201909
+      expect(config.schema_uri).to eq('https://json-schema.org/draft/2019-09/schema')
+    end
+
+    it 'returns draft 7 URI' do
+      config.schema_version = :draft7
+      expect(config.schema_uri).to eq('http://json-schema.org/draft-07/schema#')
+    end
+
+    it 'returns draft 6 URI' do
+      config.schema_version = :draft6
+      expect(config.schema_uri).to eq('http://json-schema.org/draft-06/schema#')
+    end
+
+    it 'returns draft 4 URI' do
+      config.schema_version = :draft4
+      expect(config.schema_uri).to eq('http://json-schema.org/draft-04/schema#')
+    end
+
+    it 'returns custom URI as string when unknown version' do
+      config.schema_version = 'https://custom.schema/v1'
+      expect(config.schema_uri).to eq('https://custom.schema/v1')
+    end
+  end
+
+  describe '#property_naming_strategy=' do
+    subject(:config) { described_class.new }
+
+    it 'accepts :snake_case symbol' do
+      config.property_naming_strategy = :snake_case
+      expect(config.property_naming_strategy).to eq(EasyTalk::NamingStrategies::SNAKE_CASE)
+    end
+
+    it 'accepts :camel_case symbol' do
+      config.property_naming_strategy = :camel_case
+      expect(config.property_naming_strategy).to eq(EasyTalk::NamingStrategies::CAMEL_CASE)
+    end
+
+    it 'accepts :pascal_case symbol' do
+      config.property_naming_strategy = :pascal_case
+      expect(config.property_naming_strategy).to eq(EasyTalk::NamingStrategies::PASCAL_CASE)
+    end
+
+    it 'accepts custom proc' do
+      custom_strategy = ->(name) { name.to_s.upcase.to_sym }
+      config.property_naming_strategy = custom_strategy
+      expect(config.property_naming_strategy).to eq(custom_strategy)
+    end
+  end
+
+  describe '#register_type' do
+    subject(:config) { described_class.new }
+
+    let(:custom_type) { Class.new }
+    let(:custom_builder) { Class.new(EasyTalk::Builders::BaseBuilder) }
+
+    after do
+      # Clean up registered type
+      EasyTalk::Builders::Registry.instance_variable_get(:@registry)&.delete(custom_type)
+    end
+
+    it 'delegates to Builders::Registry.register' do
+      expect(EasyTalk::Builders::Registry).to receive(:register).with(custom_type, custom_builder, collection: false)
+      config.register_type(custom_type, custom_builder)
+    end
+
+    it 'supports collection option' do
+      expect(EasyTalk::Builders::Registry).to receive(:register).with(custom_type, custom_builder, collection: true)
+      config.register_type(custom_type, custom_builder, collection: true)
+    end
   end
 end
 

--- a/spec/easy_talk/errors_helper_spec.rb
+++ b/spec/easy_talk/errors_helper_spec.rb
@@ -1,0 +1,414 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe EasyTalk::ErrorHelper do
+  describe '.raise_constraint_error' do
+    it 'raises a ConstraintError with formatted message' do
+      expect do
+        described_class.raise_constraint_error(
+          property_name: :age,
+          constraint_name: :minimum,
+          expected: Integer,
+          got: 'string'
+        )
+      end.to raise_error(
+        EasyTalk::ConstraintError,
+        "Error in property 'age': Constraint 'minimum' expects Integer, but received \"string\" (String)."
+      )
+    end
+
+    it 'includes the value class in the error message' do
+      expect do
+        described_class.raise_constraint_error(
+          property_name: :value,
+          constraint_name: :maximum,
+          expected: 'a number',
+          got: [1, 2, 3]
+        )
+      end.to raise_error(EasyTalk::ConstraintError, /\(Array\)/)
+    end
+  end
+
+  describe '.raise_array_constraint_error' do
+    it 'raises a ConstraintError with index information' do
+      expect do
+        described_class.raise_array_constraint_error(
+          property_name: :items,
+          constraint_name: :enum,
+          index: 2,
+          expected: String,
+          got: 123
+        )
+      end.to raise_error(
+        EasyTalk::ConstraintError,
+        "Error in property 'items': Constraint 'enum' at index 2 expects String, but received 123 (Integer)."
+      )
+    end
+  end
+
+  describe '.raise_unknown_option_error' do
+    it 'raises an UnknownOptionError with valid options listed' do
+      expect do
+        described_class.raise_unknown_option_error(
+          property_name: :name,
+          option: :unknown,
+          valid_options: %i[minimum maximum]
+        )
+      end.to raise_error(
+        EasyTalk::UnknownOptionError,
+        "Unknown option 'unknown' for property 'name'. Valid options are: minimum, maximum."
+      )
+    end
+
+    it 'extracts option name from hash' do
+      expect do
+        described_class.raise_unknown_option_error(
+          property_name: :name,
+          option: { invalid_key: 'value' },
+          valid_options: %i[min max]
+        )
+      end.to raise_error(EasyTalk::UnknownOptionError, /Unknown option 'invalid_key'/)
+    end
+  end
+
+  describe '.extract_inner_type' do
+    context 'with typed array' do
+      it 'extracts the raw type from typed array' do
+        type_info = T::Array[String]
+        expect(described_class.extract_inner_type(type_info)).to eq(String)
+      end
+
+      it 'extracts Integer from typed array' do
+        type_info = T::Array[Integer]
+        expect(described_class.extract_inner_type(type_info)).to eq(Integer)
+      end
+    end
+
+    context 'with boolean type' do
+      it 'returns T::Boolean for boolean typed arrays' do
+        type_info = T::Array[T::Boolean]
+        expect(described_class.extract_inner_type(type_info)).to eq(T::Boolean)
+      end
+    end
+
+    context 'with union types' do
+      it 'extracts both types from union' do
+        type_info = T.any(String, Integer)
+        result = described_class.extract_inner_type(type_info)
+        expect(result).to include(String)
+        expect(result).to include(Integer)
+      end
+    end
+
+    context 'with fallback' do
+      it 'returns Object when type cannot be extracted' do
+        expect(described_class.extract_inner_type(Object.new)).to eq(Object)
+      end
+    end
+  end
+
+  describe '.validate_typed_array_values' do
+    context 'when value is not an array' do
+      it 'raises a ConstraintError' do
+        expect do
+          described_class.validate_typed_array_values(
+            property_name: :items,
+            constraint_name: :enum,
+            type_info: T::Array[String],
+            array_value: 'not an array'
+          )
+        end.to raise_error(EasyTalk::ConstraintError, /expects String/)
+      end
+    end
+
+    context 'when array contains invalid elements' do
+      it 'raises error for wrong type at specific index' do
+        expect do
+          described_class.validate_typed_array_values(
+            property_name: :items,
+            constraint_name: :enum,
+            type_info: T::Array[String],
+            array_value: ['valid', 123, 'also valid']
+          )
+        end.to raise_error(EasyTalk::ConstraintError, /at index 1 expects String/)
+      end
+    end
+
+    context 'when array is valid' do
+      it 'does not raise error for valid string array' do
+        expect do
+          described_class.validate_typed_array_values(
+            property_name: :items,
+            constraint_name: :enum,
+            type_info: T::Array[String],
+            array_value: %w[one two three]
+          )
+        end.not_to raise_error
+      end
+
+      it 'does not raise error for valid integer array' do
+        expect do
+          described_class.validate_typed_array_values(
+            property_name: :items,
+            constraint_name: :enum,
+            type_info: T::Array[Integer],
+            array_value: [1, 2, 3]
+          )
+        end.not_to raise_error
+      end
+    end
+  end
+
+  describe '.validate_array_element' do
+    context 'with union type' do
+      it 'validates against multiple allowed types' do
+        expect do
+          described_class.validate_array_element(
+            property_name: :values,
+            constraint_name: :enum,
+            inner_type: [String, Integer],
+            element: 'valid',
+            index: 0
+          )
+        end.not_to raise_error
+      end
+
+      it 'raises error when element matches no union type' do
+        expect do
+          described_class.validate_array_element(
+            property_name: :values,
+            constraint_name: :enum,
+            inner_type: [String, Integer],
+            element: 3.14,
+            index: 0
+          )
+        end.to raise_error(EasyTalk::ConstraintError, /expects String or Integer/)
+      end
+    end
+
+    context 'with single type' do
+      it 'validates element type' do
+        expect do
+          described_class.validate_array_element(
+            property_name: :values,
+            constraint_name: :enum,
+            inner_type: String,
+            element: 123,
+            index: 0
+          )
+        end.to raise_error(EasyTalk::ConstraintError)
+      end
+    end
+  end
+
+  describe '.validate_union_element' do
+    it 'allows element matching any type in union' do
+      expect do
+        described_class.validate_union_element(:field, :constraint, [String, Integer], 'string', 0)
+      end.not_to raise_error
+
+      expect do
+        described_class.validate_union_element(:field, :constraint, [String, Integer], 42, 0)
+      end.not_to raise_error
+    end
+
+    it 'raises error when element matches no type' do
+      expect do
+        described_class.validate_union_element(:field, :constraint, [String, Integer], [], 0)
+      end.to raise_error(EasyTalk::ConstraintError)
+    end
+  end
+
+  describe '.validate_single_type_element' do
+    it 'allows boolean values regardless of expected type' do
+      expect do
+        described_class.validate_single_type_element(:field, :constraint, String, true, 0)
+      end.not_to raise_error
+    end
+
+    it 'raises error for invalid boolean when boolean expected' do
+      expect do
+        described_class.validate_single_type_element(:field, :constraint, T::Boolean, 'not_boolean', 0)
+      end.to raise_error(EasyTalk::ConstraintError, /Boolean/)
+    end
+
+    it 'raises error for type mismatch' do
+      expect do
+        described_class.validate_single_type_element(:field, :constraint, Integer, 'string', 0)
+      end.to raise_error(EasyTalk::ConstraintError)
+    end
+
+    it 'allows matching type' do
+      expect do
+        described_class.validate_single_type_element(:field, :constraint, String, 'valid', 0)
+      end.not_to raise_error
+    end
+  end
+
+  describe '.validate_constraint_value' do
+    context 'with nil value' do
+      it 'returns early without error' do
+        expect do
+          described_class.validate_constraint_value(
+            property_name: :field,
+            constraint_name: :minimum,
+            value_type: Integer,
+            value: nil
+          )
+        end.not_to raise_error
+      end
+    end
+
+    context 'with boolean type' do
+      it 'accepts true' do
+        expect do
+          described_class.validate_constraint_value(
+            property_name: :field,
+            constraint_name: :default,
+            value_type: T::Boolean,
+            value: true
+          )
+        end.not_to raise_error
+      end
+
+      it 'accepts false' do
+        expect do
+          described_class.validate_constraint_value(
+            property_name: :field,
+            constraint_name: :default,
+            value_type: T::Boolean,
+            value: false
+          )
+        end.not_to raise_error
+      end
+
+      it 'rejects non-boolean' do
+        expect do
+          described_class.validate_constraint_value(
+            property_name: :field,
+            constraint_name: :default,
+            value_type: T::Boolean,
+            value: 'true'
+          )
+        end.to raise_error(EasyTalk::ConstraintError, /Boolean/)
+      end
+
+      it 'accepts array of booleans' do
+        expect do
+          described_class.validate_constraint_value(
+            property_name: :field,
+            constraint_name: :enum,
+            value_type: T::Boolean,
+            value: [true, false]
+          )
+        end.not_to raise_error
+      end
+    end
+
+    context 'with simple scalar types' do
+      it 'validates String type' do
+        expect do
+          described_class.validate_constraint_value(
+            property_name: :name,
+            constraint_name: :default,
+            value_type: String,
+            value: 'valid'
+          )
+        end.not_to raise_error
+      end
+
+      it 'raises error for String type mismatch' do
+        expect do
+          described_class.validate_constraint_value(
+            property_name: :name,
+            constraint_name: :default,
+            value_type: String,
+            value: 123
+          )
+        end.to raise_error(EasyTalk::ConstraintError)
+      end
+
+      it 'validates Integer type' do
+        expect do
+          described_class.validate_constraint_value(
+            property_name: :count,
+            constraint_name: :minimum,
+            value_type: Integer,
+            value: 42
+          )
+        end.not_to raise_error
+      end
+
+      it 'raises error for Integer type mismatch' do
+        expect do
+          described_class.validate_constraint_value(
+            property_name: :count,
+            constraint_name: :minimum,
+            value_type: Integer,
+            value: '42'
+          )
+        end.to raise_error(EasyTalk::ConstraintError)
+      end
+    end
+
+    context 'with typed array' do
+      it 'validates array elements' do
+        expect do
+          described_class.validate_constraint_value(
+            property_name: :items,
+            constraint_name: :enum,
+            value_type: T::Array[String],
+            value: %w[a b c]
+          )
+        end.not_to raise_error
+      end
+
+      it 'raises error for invalid array elements' do
+        expect do
+          described_class.validate_constraint_value(
+            property_name: :items,
+            constraint_name: :enum,
+            value_type: T::Array[String],
+            value: ['valid', 123]
+          )
+        end.to raise_error(EasyTalk::ConstraintError)
+      end
+    end
+
+    context 'with union Sorbet type' do
+      it 'validates against union of types' do
+        expect do
+          described_class.validate_constraint_value(
+            property_name: :value,
+            constraint_name: :default,
+            value_type: T.any(String, Integer),
+            value: 'string'
+          )
+        end.not_to raise_error
+      end
+
+      it 'accepts integer in union' do
+        expect do
+          described_class.validate_constraint_value(
+            property_name: :value,
+            constraint_name: :default,
+            value_type: T.any(String, Integer),
+            value: 42
+          )
+        end.not_to raise_error
+      end
+
+      it 'raises error for value not in union' do
+        expect do
+          described_class.validate_constraint_value(
+            property_name: :value,
+            constraint_name: :default,
+            value_type: T.any(String, Integer),
+            value: 3.14
+          )
+        end.to raise_error(EasyTalk::ConstraintError, /String or Integer/)
+      end
+    end
+  end
+end

--- a/spec/easy_talk/naming_strategies_spec.rb
+++ b/spec/easy_talk/naming_strategies_spec.rb
@@ -51,4 +51,68 @@ RSpec.describe EasyTalk::NamingStrategies do
       expect(EasyTalk::NamingStrategies::PASCAL_CASE.call(:camelCase)).to eq(:CamelCase)
     end
   end
+
+  describe '.derive_strategy' do
+    context 'with symbol strategies' do
+      it 'returns IDENTITY strategy for :identity' do
+        strategy = described_class.derive_strategy(:identity)
+        expect(strategy).to eq(EasyTalk::NamingStrategies::IDENTITY)
+      end
+
+      it 'returns SNAKE_CASE strategy for :snake_case' do
+        strategy = described_class.derive_strategy(:snake_case)
+        expect(strategy).to eq(EasyTalk::NamingStrategies::SNAKE_CASE)
+      end
+
+      it 'returns CAMEL_CASE strategy for :camel_case' do
+        strategy = described_class.derive_strategy(:camel_case)
+        expect(strategy).to eq(EasyTalk::NamingStrategies::CAMEL_CASE)
+      end
+
+      it 'returns PASCAL_CASE strategy for :pascal_case' do
+        strategy = described_class.derive_strategy(:pascal_case)
+        expect(strategy).to eq(EasyTalk::NamingStrategies::PASCAL_CASE)
+      end
+
+      it 'raises NameError for unknown symbol strategy' do
+        expect do
+          described_class.derive_strategy(:unknown_strategy)
+        end.to raise_error(NameError)
+      end
+    end
+
+    context 'with Proc strategies' do
+      it 'returns the provided proc unchanged' do
+        custom_proc = ->(name) { name.to_s.reverse.to_sym }
+        strategy = described_class.derive_strategy(custom_proc)
+        expect(strategy).to eq(custom_proc)
+      end
+
+      it 'allows custom transformations' do
+        custom_proc = ->(name) { name.to_s.upcase.to_sym }
+        strategy = described_class.derive_strategy(custom_proc)
+        expect(strategy.call(:hello)).to eq(:HELLO)
+      end
+    end
+
+    context 'with invalid strategy type' do
+      it 'raises TypeError for string' do
+        expect do
+          described_class.derive_strategy('identity')
+        end.to raise_error(TypeError)
+      end
+
+      it 'raises TypeError for integer' do
+        expect do
+          described_class.derive_strategy(123)
+        end.to raise_error(TypeError)
+      end
+
+      it 'raises TypeError for array' do
+        expect do
+          described_class.derive_strategy([:identity])
+        end.to raise_error(TypeError)
+      end
+    end
+  end
 end

--- a/spec/easy_talk/property_spec.rb
+++ b/spec/easy_talk/property_spec.rb
@@ -186,4 +186,139 @@ RSpec.describe EasyTalk::Property do
       end
     end
   end
+
+  describe 'nilable types' do
+    it 'returns schema with type array for T.nilable(String)' do
+      prop = described_class.new(:name, T.nilable(String)).build
+      expect(prop[:type]).to eq(%w[string null])
+    end
+
+    it 'returns schema with type array for T.nilable(Integer)' do
+      prop = described_class.new(:count, T.nilable(Integer)).build
+      expect(prop[:type]).to eq(%w[integer null])
+    end
+
+    it 'returns just null type when underlying type cannot be determined' do
+      prop = described_class.new(:nothing, NilClass).build
+      expect(prop).to eq({ type: 'null' })
+    end
+
+    it 'preserves constraints for nilable types' do
+      prop = described_class.new(:name, T.nilable(String), min_length: 1).build
+      expect(prop[:type]).to eq(%w[string null])
+      expect(prop[:minLength]).to eq(1)
+    end
+  end
+
+  describe '$ref support' do
+    let(:model_class) do
+      Class.new do
+        include EasyTalk::Model
+
+        def self.name
+          'RefModel'
+        end
+
+        define_schema do
+          property :field, String
+        end
+      end
+    end
+
+    context 'with ref: true constraint' do
+      around do |example|
+        original_use_refs = EasyTalk.configuration.use_refs
+        EasyTalk.configuration.use_refs = false
+        example.run
+        EasyTalk.configuration.use_refs = original_use_refs
+      end
+
+      it 'returns $ref schema for EasyTalk model' do
+        prop = described_class.new(:nested, model_class, ref: true).build
+        expect(prop).to have_key(:$ref)
+        expect(prop[:$ref]).to eq('#/$defs/RefModel')
+      end
+
+      it 'preserves other constraints with $ref' do
+        prop = described_class.new(:nested, model_class, ref: true, description: 'A nested model').build
+        expect(prop[:$ref]).to eq('#/$defs/RefModel')
+        expect(prop[:description]).to eq('A nested model')
+      end
+    end
+
+    context 'with global use_refs enabled' do
+      around do |example|
+        original_use_refs = EasyTalk.configuration.use_refs
+        EasyTalk.configuration.use_refs = true
+        example.run
+        EasyTalk.configuration.use_refs = original_use_refs
+      end
+
+      it 'uses $ref by default' do
+        prop = described_class.new(:nested, model_class).build
+        expect(prop).to have_key(:$ref)
+      end
+
+      it 'respects ref: false to inline' do
+        prop = described_class.new(:nested, model_class, ref: false).build
+        expect(prop).not_to have_key(:$ref)
+        expect(prop[:type]).to eq('object')
+      end
+    end
+
+    context 'with nilable EasyTalk model and $ref' do
+      around do |example|
+        original_use_refs = EasyTalk.configuration.use_refs
+        EasyTalk.configuration.use_refs = true
+        example.run
+        EasyTalk.configuration.use_refs = original_use_refs
+      end
+
+      it 'uses anyOf with $ref and null for nilable model' do
+        prop = described_class.new(:nested, T.nilable(model_class)).build
+        expect(prop).to have_key(:anyOf)
+        any_of = prop[:anyOf]
+        expect(any_of).to include({ '$ref': '#/$defs/RefModel' })
+        expect(any_of).to include({ type: 'null' })
+      end
+    end
+  end
+
+  describe '#find_builder_for_type' do
+    it 'resolves builder for String type' do
+      prop = described_class.new(:name, String)
+      result = prop.send(:find_builder_for_type)
+      expect(result.first).to eq(EasyTalk::Builders::StringBuilder)
+    end
+
+    it 'resolves builder for Integer type' do
+      prop = described_class.new(:count, Integer)
+      result = prop.send(:find_builder_for_type)
+      expect(result.first).to eq(EasyTalk::Builders::IntegerBuilder)
+    end
+
+    it 'resolves builder for typed array' do
+      prop = described_class.new(:items, T::Array[String])
+      result = prop.send(:find_builder_for_type)
+      expect(result.first).to eq(EasyTalk::Builders::TypedArrayBuilder)
+      expect(result.last).to be true
+    end
+  end
+
+  describe '#nilable_type?' do
+    it 'returns true for T.nilable types' do
+      prop = described_class.new(:name, T.nilable(String))
+      expect(prop.send(:nilable_type?)).to be true
+    end
+
+    it 'returns false for non-nilable types' do
+      prop = described_class.new(:name, String)
+      expect(prop.send(:nilable_type?)).to be false
+    end
+
+    it 'returns false for types without :types method' do
+      prop = described_class.new(:name, Integer)
+      expect(prop.send(:nilable_type?)).to be false
+    end
+  end
 end

--- a/spec/easy_talk/ref_helper_spec.rb
+++ b/spec/easy_talk/ref_helper_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe EasyTalk::RefHelper do
+  let(:model_class) do
+    Class.new do
+      include EasyTalk::Model
+
+      def self.name
+        'TestModel'
+      end
+
+      define_schema do
+        property :name, String
+      end
+    end
+  end
+
+  let(:non_model_class) do
+    Class.new do
+      def self.name
+        'PlainClass'
+      end
+    end
+  end
+
+  describe '.should_use_ref?' do
+    context 'with non-model type' do
+      it 'returns false for plain classes' do
+        expect(described_class.should_use_ref?(non_model_class, {})).to be false
+      end
+
+      it 'returns false for primitive types' do
+        expect(described_class.should_use_ref?(String, {})).to be false
+        expect(described_class.should_use_ref?(Integer, {})).to be false
+      end
+    end
+
+    context 'with EasyTalk model' do
+      context 'when ref constraint is explicitly set' do
+        it 'returns true when ref: true' do
+          expect(described_class.should_use_ref?(model_class, { ref: true })).to be true
+        end
+
+        it 'returns false when ref: false' do
+          expect(described_class.should_use_ref?(model_class, { ref: false })).to be false
+        end
+      end
+
+      context 'when using global configuration' do
+        around do |example|
+          original_use_refs = EasyTalk.configuration.use_refs
+          example.run
+          EasyTalk.configuration.use_refs = original_use_refs
+        end
+
+        it 'returns true when global use_refs is true' do
+          EasyTalk.configuration.use_refs = true
+          expect(described_class.should_use_ref?(model_class, {})).to be true
+        end
+
+        it 'returns false when global use_refs is false' do
+          EasyTalk.configuration.use_refs = false
+          expect(described_class.should_use_ref?(model_class, {})).to be false
+        end
+
+        it 'per-property constraint overrides global config' do
+          EasyTalk.configuration.use_refs = true
+          expect(described_class.should_use_ref?(model_class, { ref: false })).to be false
+        end
+      end
+    end
+  end
+
+  describe '.should_use_ref_for_type?' do
+    context 'with non-model type' do
+      it 'returns false' do
+        expect(described_class.should_use_ref_for_type?(String, {})).to be false
+      end
+    end
+
+    context 'with EasyTalk model' do
+      around do |example|
+        original_use_refs = EasyTalk.configuration.use_refs
+        example.run
+        EasyTalk.configuration.use_refs = original_use_refs
+      end
+
+      it 'respects ref constraint over global config' do
+        EasyTalk.configuration.use_refs = false
+        expect(described_class.should_use_ref_for_type?(model_class, { ref: true })).to be true
+      end
+
+      it 'falls back to global config when no constraint' do
+        EasyTalk.configuration.use_refs = true
+        expect(described_class.should_use_ref_for_type?(model_class, {})).to be true
+      end
+    end
+  end
+
+  describe '.build_ref_schema' do
+    it 'creates schema with $ref pointing to model' do
+      result = described_class.build_ref_schema(model_class, {})
+      expect(result).to eq({ '$ref': '#/$defs/TestModel' })
+    end
+
+    it 'excludes ref constraint from output' do
+      result = described_class.build_ref_schema(model_class, { ref: true })
+      expect(result).to eq({ '$ref': '#/$defs/TestModel' })
+      expect(result).not_to have_key(:ref)
+    end
+
+    it 'excludes optional constraint from output' do
+      result = described_class.build_ref_schema(model_class, { optional: true })
+      expect(result).to eq({ '$ref': '#/$defs/TestModel' })
+      expect(result).not_to have_key(:optional)
+    end
+
+    it 'preserves other constraints' do
+      result = described_class.build_ref_schema(model_class, { title: 'Test', description: 'A test model' })
+      expect(result).to eq({
+                             '$ref': '#/$defs/TestModel',
+                             title: 'Test',
+                             description: 'A test model'
+                           })
+    end
+
+    it 'handles multiple constraints correctly' do
+      result = described_class.build_ref_schema(model_class, {
+                                                  ref: true,
+                                                  optional: true,
+                                                  title: 'Test',
+                                                  description: 'Desc'
+                                                })
+      expect(result.keys).to contain_exactly(:$ref, :title, :description)
+    end
+  end
+end


### PR DESCRIPTION
Closes #135

- Create errors_helper_spec.rb with tests for constraint error generation, array validation, union type validation, and value type checking
- Create ref_helper_spec.rb with tests for $ref schema generation, per-property and global configuration settings
- Extend configuration_spec.rb with tests for schema_uri, property_naming_strategy, register_type, and all default configuration values
- Extend naming_strategies_spec.rb with tests for derive_strategy method including symbol/Proc strategies and error handling
- Extend property_spec.rb with tests for nilable types, $ref support, and private method behavior