### PR TITLE
Fix ReDoS vulnerability in pattern validation

### DIFF
--- a/lib/easy_talk/validation_adapters/active_model_adapter.rb
+++ b/lib/easy_talk/validation_adapters/active_model_adapter.rb
@@ -90,8 +90,13 @@ module EasyTalk
 
         # Handle pattern (regex) constraints
         if @constraints[:pattern]
-          @klass.validates @property_name, format: { with: Regexp.new(@constraints[:pattern]) },
-                                           allow_nil: optional?
+          begin
+            regex = Regexp.new(@constraints[:pattern], timeout: 1.0)
+            @klass.validates @property_name, format: { with: regex },
+                                             allow_nil: optional?
+          rescue RegexpError => e
+            raise ArgumentError, "Invalid regex pattern for #{@property_name}: #{e.message}"
+          end
         end
 
         # Handle length constraints


### PR DESCRIPTION
Add timeout protection and error handling for user-provided regex patterns in ActiveModelAdapter. Previously, Regexp.new() was called directly on constraint patterns without any protection, which could allow malicious patterns to cause catastrophic backtracking and denial of service.

Changes:
- Add 1 second timeout to compiled regex patterns
- Wrap Regexp.new in begin/rescue to handle invalid patterns
- Raise ArgumentError with clear message for invalid patterns