### PR TITLE
Potential fix for code scanning alert no. 1: Code injection

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -14,8 +14,10 @@ jobs:
       contains(github.event.comment.body, '/gemini-review')
     steps:
       - name: PR Info
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          echo "Comment: ${{ github.event.comment.body }}"
+          echo "Comment: $COMMENT_BODY"
           echo "Issue Number: ${{ github.event.issue.number }}"
           echo "Repository: ${{ github.repository }}"
 


### PR DESCRIPTION
Potential fix for [https://github.com/sergiobayona/easy_talk/security/code-scanning/1](https://github.com/sergiobayona/easy_talk/security/code-scanning/1)

To fix this, the untrusted `github.event.comment.body` should not be inlined directly into the `run:` script via expression syntax. Instead, assign it to an environment variable via `env:` on the step, and then reference that variable using shell syntax (`"$COMMENT_BODY"`). This prevents the shell from re-interpreting GitHub’s expression expansion and follows the best-practice pattern described in the background.

Concretely, in `.github/workflows/code-review.yml`, modify the "PR Info" step (lines 16–21). Add an `env:` section with a key like `COMMENT_BODY: ${{ github.event.comment.body }}`. Then change the `run:` script to use `echo "Comment: $COMMENT_BODY"` instead of `echo "Comment: ${{ github.event.comment.body }}"`. Leave the other `echo` lines (for issue number and repository) as-is since they are not user-controlled. No additional imports or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
