### PR TITLE
Fix optional array properties incorrectly rejecting nil

### DIFF
--- a/lib/easy_talk/validation_adapters/active_model_adapter.rb
+++ b/lib/easy_talk/validation_adapters/active_model_adapter.rb
@@ -559,7 +559,7 @@ module EasyTalk
         end
 
         def array_requires_presence_validation?
-          @array_type && !@nilable
+          @array_type && !@nilable && !@optional
         end
 
         def tuple_type?

--- a/spec/easy_talk/optional_array_nil_spec.rb
+++ b/spec/easy_talk/optional_array_nil_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Optional array properties and nil acceptance' do
+  context 'when array property is optional' do
+    let(:klass) do
+      Class.new do
+        include EasyTalk::Model
+
+        def self.name = 'OptionalArrayModel'
+
+        define_schema do
+          property :tags, T::Array[String], optional: true
+        end
+      end
+    end
+
+    it 'accepts nil (property omitted)' do
+      obj = klass.new
+      expect(obj).to be_valid
+    end
+
+    it 'accepts an empty array' do
+      obj = klass.new(tags: [])
+      expect(obj).to be_valid
+    end
+
+    it 'accepts a populated array' do
+      obj = klass.new(tags: %w[ruby python])
+      expect(obj).to be_valid
+    end
+
+    it 'does not include property in required' do
+      expect(klass.json_schema['required']).to be_nil
+    end
+  end
+
+  context 'when array property is required (default)' do
+    let(:klass) do
+      Class.new do
+        include EasyTalk::Model
+
+        def self.name = 'RequiredArrayModel'
+
+        define_schema do
+          property :tags, T::Array[String]
+        end
+      end
+    end
+
+    it 'rejects nil' do
+      obj = klass.new
+      expect(obj).not_to be_valid
+      expect(obj.errors[:tags]).to include("can't be blank")
+    end
+
+    it 'accepts an empty array' do
+      obj = klass.new(tags: [])
+      expect(obj).to be_valid
+    end
+
+    it 'accepts a populated array' do
+      obj = klass.new(tags: %w[ruby python])
+      expect(obj).to be_valid
+    end
+  end
+end

--- a/spec/easy_talk/validation_adapters/active_model_adapter_spec.rb
+++ b/spec/easy_talk/validation_adapters/active_model_adapter_spec.rb
@@ -266,12 +266,11 @@ RSpec.describe EasyTalk::ValidationAdapters::ActiveModelAdapter do
         end
       end
 
-      # Per JSON Schema: optional means the property can be omitted from the object,
-      # but if present, null is still invalid unless type includes null
-      it 'rejects nil for optional non-nilable array properties' do
+      # In Ruby, an omitted property is indistinguishable from nil.
+      # Optional means the property can be absent, so nil must be accepted.
+      it 'accepts nil for optional array properties' do
         instance = test_class.new(tags: nil)
-        expect(instance.valid?).to be false
-        expect(instance.errors[:tags]).to include("can't be blank")
+        expect(instance.valid?).to be true
       end
 
       it 'validates empty arrays as valid' do


### PR DESCRIPTION
`array_requires_presence_validation?` did not check `@optional`, so optional array properties added a nil-check that contradicted the JSON Schema (which correctly omitted the property from `required`). In Ruby an omitted property is indistinguishable from nil, so optional arrays must accept nil.